### PR TITLE
Fix for NREs when warping to other systems.

### DIFF
--- a/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchOnPlanetModelingManager.cs
+++ b/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchOnPlanetModelingManager.cs
@@ -623,8 +623,8 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
                 if (planet.dirtyFlags.Length != 0)
                     for (var i = 0; i < planet.dirtyFlags.Length; i++)
                         planet.dirtyFlags[i] = true;
-
-            if (GameMain.isRunning) planet.UpdateDirtyMeshes();
+            // Planet.wanted shows that we've modeled the planet and are keeping it. Modeling stage will be 0 in this postfix only AFTER modeling stage 4 is complete.
+            if (GameMain.isRunning && planet.wanted && ___currentModelingStage == 0) planet.UpdateDirtyMeshes();
         }
     }
 }


### PR DESCRIPTION
PlanetModelingManager.ModelingPlanetMain is designed to divide its work,
and runs through 5 stages (0-4).
We were attempting to call planet.UpdateDirtyMeshes() after any call to
this function, rather than specifically after all 5 stages were complete.

Fix: check that the planet we were working with is valid, and that the
current modeling stage counter had been reset to 0 after completing the
modeling process.