### PR TITLE
Fix bug with planet size selection

### DIFF
--- a/DSP_Plugins.GalacticScale/Scripts/PatchStarSystemGeneration/Rework/ReworkCreatePlanet.cs
+++ b/DSP_Plugins.GalacticScale/Scripts/PatchStarSystemGeneration/Rework/ReworkCreatePlanet.cs
@@ -412,6 +412,7 @@ namespace GalacticScale.Scripts.PatchStarSystemGeneration {
                                     }
                                 }
                             }
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Foreach loop wasn't exiting once a matching size had been found, therefore always selecting the last value in the array