### PR TITLE
Backwards Compatibility with 1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !*/**/Release/**
 bin/
 obj/
+DSP_Plugins.GalacticScale/DSP_Plugins.GalacticScale.csproj

--- a/DSP_Plugins.GalacticScale/DSP_Plugins.GalacticScale.csproj
+++ b/DSP_Plugins.GalacticScale/DSP_Plugins.GalacticScale.csproj
@@ -35,16 +35,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\Libs\0Harmony.dll</HintPath>
+      <HintPath>..\..\bep\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>G:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\Libs\BepInEx.dll</HintPath>
+      <HintPath>..\..\bep\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Harmony">
-      <HintPath>..\Libs\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\..\bep\BepInEx.Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,19 +54,19 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\Libs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\Libs\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\Libs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\Libs\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchForPlanetSize.cs
+++ b/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchForPlanetSize.cs
@@ -6,10 +6,11 @@ using BepInEx.Logging;
 using HarmonyLib;
 
 namespace GalacticScale.Scripts.PatchPlanetSize {
-    [BepInPlugin("dsp.galactic-scale.planet-size", "Galactic Scale Plug-In - Planet Size", "1.0.0.0")]
+    [BepInPlugin("dsp.galactic-scale.planet-size", "Galactic Scale Plug-In - Planet Size", "1.1.0.0")]
     public class PatchForPlanetSize : BaseUnityPlugin {
         public new static ManualLogSource Logger;
 
+        public static string Version = "1.3.2.1";
         public static bool DebugGeneral = false;
         public static bool DebugPlanetRawData = false;
         public static bool DebugGetModPlane = false;
@@ -18,7 +19,7 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
         public static bool DebugPlanetModelingManagerDeep = false;
         public static bool DebugAtmoBlur = false;
 
-
+        public static bool Break = true; // If false, don't break while selecting planet sizes to enable save load from 1.3.1
         public static float VanillaGasGiantSize = 800f;// will be rescaled in the create planet
         public static float VanillaGasGiantScale = 10f;// will be rescaled in the create planet
         public static float VanillaTelluricSize = 200f;
@@ -28,7 +29,7 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
         public static Dictionary<int, float> PlanetSizeParams = new Dictionary<int, float>();
         public static List<int> PlanetSizeList = new List<int>();
 
-
+        public static ConfigEntry<bool> OldPlanetSelection;
         public static ConfigEntry<bool> EnableResizingFeature;
         public static ConfigEntry<bool> EnableLimitedResizingFeature;
         public static ConfigEntry<bool> EnableMoonSizeFailSafe;
@@ -71,6 +72,10 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
                 "LimitedResizingArray",
                 "50,100,200",
                 "limited version of the resizing feature : will be here the time we fix the other one");
+            OldPlanetSelection = Config.Bind("galactic-scale-planets-size",
+                "OldPlanetSelection",
+                false,
+                "use the broken planet selection from 1.3.1 to prevent small planets on older saves");
 
             LimitedResizingChances = Config.Bind("galactic-scale-planets-size",
                 "LimitedResizingChances",
@@ -117,6 +122,10 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
                 1200f,
                 "Used to create variation on the planet size : help defining the min & max size for a gas giant --  -- Not Advised to modify YET");
 
+            if (OldPlanetSelection.Value)
+            {
+                Break = !OldPlanetSelection.Value;
+            }
             if (EnableResizingFeature.Value || EnableLimitedResizingFeature.Value) {
 
                 ParseResizinSettings(LimitedResizingArray.Value, LimitedResizingChances.Value);

--- a/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchForPlanetSize.cs
+++ b/DSP_Plugins.GalacticScale/Scripts/PatchPlanetSize/PatchForPlanetSize.cs
@@ -63,6 +63,12 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
             //Adding the Logger
             Logger = new ManualLogSource("PatchForPlanetSize");
             BepInEx.Logging.Logger.Sources.Add(Logger);
+
+            OldPlanetSelection = Config.Bind("galactic-scale-planets-size",
+               "OldPlanetSelection",
+               false,
+               "use the broken planet selection from 1.3.1 to prevent small planets on older saves");
+
             EnableLimitedResizingFeature = Config.Bind("galactic-scale-planets-size",
                 "EnableLimitedResizingFeature",
                 true,
@@ -72,10 +78,6 @@ namespace GalacticScale.Scripts.PatchPlanetSize {
                 "LimitedResizingArray",
                 "50,100,200",
                 "limited version of the resizing feature : will be here the time we fix the other one");
-            OldPlanetSelection = Config.Bind("galactic-scale-planets-size",
-                "OldPlanetSelection",
-                false,
-                "use the broken planet selection from 1.3.1 to prevent small planets on older saves");
 
             LimitedResizingChances = Config.Bind("galactic-scale-planets-size",
                 "LimitedResizingChances",

--- a/DSP_Plugins.GalacticScale/Scripts/PatchStarSystemGeneration/Rework/ReworkCreatePlanet.cs
+++ b/DSP_Plugins.GalacticScale/Scripts/PatchStarSystemGeneration/Rework/ReworkCreatePlanet.cs
@@ -401,7 +401,7 @@ namespace GalacticScale.Scripts.PatchStarSystemGeneration {
                                                     planetData.precision = PatchSize.PlanetSizeList[i - 1];
                                                     segments = (int) (planetData.radius / 4f + 0.1f) * 4;
                                                     PatchSizeReworkPlanetGen.SetLuts(segments, planetData.radius);
-                                                    break;
+                                                    if (PatchSize.Break) break;
                                                 }
                                             }
                                         }
@@ -410,7 +410,7 @@ namespace GalacticScale.Scripts.PatchStarSystemGeneration {
                             }
                             
                         }
-                        break;
+                        if (PatchSize.Break) break;
                     }
                 }
                 else {


### PR DESCRIPTION
Added config option to revert changes to ReworkCreatePlanet.cs that broke saves
------------------
You will need to open dsp.galactic-scale.planet-size.cfg in a text editor and add the following line

OldPlanetSelection = true
------------------
Obviously, if you are starting a new game, don't do this, as you will miss out on varied planet sizes.