### PR TITLE
add Translate() to GS2dev Settings, Main Settings, Init messages

### DIFF
--- a/GalacticScale2/Scripts/GalacticScale2.0/Generators/GS2Dev/Settings.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/Generators/GS2Dev/Settings.cs
@@ -436,7 +436,7 @@ namespace GalacticScale.Generators
             Options.Add(GSUI.Group("Star Relative Frequencies".Translate(), FreqOptions, "How often to select a star type".Translate()));
             Options.Add(GSUI.Spacer());
             Options.Add(GSUI.Header("Default Settings".Translate(), "Changing these will reset all star specific options below".Translate()));
-            UI.Add("planetCount", Options.Add(GSUI.RangeSlider("Planet Count".Translate(), 1, 2, 10, 99, 1f, "planetCount", null, planetCountLow, planetCountHigh, "Size of Starting Planet. 200 is normal".Translate())));
+            UI.Add("planetCount", Options.Add(GSUI.RangeSlider("Planet Count".Translate(), 1, 2, 10, 99, 1f, "planetCount", null, planetCountLow, planetCountHigh, "The amount of planets per star".Translate())));
             UI.Add("countBias", Options.Add(GSUI.Slider("Planet Count Bias".Translate(), 0, 50, 100, "sizeBias", CountBiasCallback)));
             UI.Add("planetSize",Options.Add(GSUI.PlanetSizeRangeSlider("Telluric Planet Size".Translate(), 5, 50, 400, 510, "planetSize", planetSize, planetSizeLow, planetSizeHigh, "Min/Max Size of Rocky Planets".Translate())));
             UI.Add("sizeBias", Options.Add(GSUI.Slider("Planet Size Bias".Translate(), 0, 50, 100, "sizeBias", SizeBiasCallback)));

--- a/GalacticScale2/Scripts/GalacticScale2.0/Generators/GS2Dev/Settings.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/Generators/GS2Dev/Settings.cs
@@ -370,14 +370,14 @@ namespace GalacticScale.Generators
             {
                 if ((bool) o) EnableSafeMode();
                 else DisableSafeMode();
-            }, "Disabled for now")));
+            }, "Disabled for now".Translate())));
             
             
             UI.Add("ludicrousMode", Options.Add(GSUI.Checkbox("Ludicrous Mode".Translate(), false, "ludicrousMode", o =>
             {
                 if ((bool) o) EnableLudicrousMode();
                 else DisableLudicrousMode();
-            }, "Disabled for now")));
+            }, "Disabled for now".Translate())));
             
             UI.Add("galaxyDensity", Options.Add(GSUI.Slider("Galaxy Density".Translate(), 1, 5, 9, "galaxyDensity", null, "Higher = Stars are closer to each other".Translate())));
             UI.Add("defaultStarCount",
@@ -391,7 +391,7 @@ namespace GalacticScale.Generators
             UI.Add("birthPlanetUnlock",
                 bOptions.Add(GSUI.Checkbox("Starting Planet Unlock".Translate(), false, "birthPlanetUnlock", null, "Allow other habitable themes for birth planet".Translate())));
             UI.Add("birthPlanetSiTi", bOptions.Add(GSUI.Checkbox("Starting planet Si/Ti".Translate(), false, "birthPlanetSiTi", null, "Force Silicon and Titanius on the birth planet".Translate())));
-            UI.Add("birthPlanetStar", bOptions.Add(GSUI.Combobox("BirthPlanet Star", starTypes, 7, "birthStar",null, "Type of Star to Start at")));
+            UI.Add("birthPlanetStar", bOptions.Add(GSUI.Combobox("BirthPlanet Star".Translate(), starTypes, 7, "birthStar",null, "Type of Star to Start at".Translate())));
             Options.Add(GSUI.Group("Birth Planet Settings".Translate(), bOptions, "Settings that only affect the starting planet".Translate()));
             UI.Add("moonsAreSmall", Options.Add(GSUI.Checkbox("Moons Are Small".Translate(), true, "moonsAreSmall", null, "Try to ensure moons are 1/2 their planets size or less".Translate())));
             UI.Add("moonBias", Options.Add(GSUI.Slider("Gas Giants Moon Bias".Translate(), 0, 50, 100, "moonBias", null, "Lower prefers telluric plants, higher gas giants".Translate())));
@@ -402,7 +402,7 @@ namespace GalacticScale.Generators
             UI.Add("allowResonances", Options.Add(GSUI.Checkbox("Allow Orbital Harmonics".Translate(), true, "allowResonances", null, "Allow Orbital Resonance 1:2 and 1:4".Translate())));
             UI.Add("rotationMulti", Options.Add(GSUI.Slider("Rotation Multiplier".Translate(), 0.5f, 1, 100, 0.5f, "rotationMulti", null, "Increase the duration of night/day".Translate())));
             UI.Add("secondarySatellites",
-                Options.Add(GSUI.Checkbox("Secondary satellites".Translate(), false, "secondarySatellites", null, "Allow moons to have moons")));
+                Options.Add(GSUI.Checkbox("Secondary satellites".Translate(), false, "secondarySatellites", null, "Allow moons to have moons".Translate())));
 
             var FreqOptions = new GSOptions();
             UI.Add("freqK", FreqOptions.Add(GSUI.Slider("Freq. Type K".Translate(), 0, 40, 100, "freqK")));

--- a/GalacticScale2/Scripts/GalacticScale2.0/Init.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/Init.cs
@@ -70,10 +70,10 @@ namespace GalacticScale
 
                 if (bundle == null)
                 {
-                    Error("Failed to load AssetBundle!");
+                    Error("Failed to load AssetBundle!".Translate());
                     UIMessageBox.Show("Error",
-                        "Asset Bundle not found. \r\nPlease ensure your directory structure is correct.\r\n Installation instructions can be found at http://customizing.space/release. \r\nAn error log has been generated in the plugin/ErrorLog Directory",
-                        "Return", 0);
+                        "Asset Bundle not found. \r\nPlease ensure your directory structure is correct.\r\n Installation instructions can be found at http://customizing.space/release. \r\nAn error log has been generated in the plugin/ErrorLog Directory".Translate(),
+                        "Return".Translate(), 0);
 
                     return null;
                 }
@@ -88,7 +88,7 @@ namespace GalacticScale
             if (File.Exists(Path.Combine(AssemblyPath, "icon.png")))
             {
                 updateMessage +=
-                    "Update Detected. Please do not save over existing saves \r\nuntil you are sure you can load saves saved with this version!\r\nPlease note the settings panel is under construction, and missing options will reappear in future updates\r\nPlease Click GS2 Help and click the link to join our community on discord for preview builds and to help shape the mod going forward";
+                    "Update Detected. Please do not save over existing saves \r\nuntil you are sure you can load saves saved with this version!\r\nPlease note the settings panel is under construction, and missing options will reappear in future updates\r\nPlease Click GS2 Help and click the link to join our community on discord for preview builds and to help shape the mod going forward".Translate();
                 File.Delete(Path.Combine(AssemblyPath, "icon.png"));
             }
             Warn("Start");
@@ -98,7 +98,7 @@ namespace GalacticScale
                 Warn($"Moving Configs from {OldDataDir} to {DataDir}");
                 Directory.Move(OldDataDir, DataDir);
                 updateMessage +=
-                    "Galactic Scale config Directory has changed to \r\n ...\\BepInEx\\config\\GalacticScale \r\nThis is to prevent data being lost when updating using the mod manager.\r\n";
+                    "Galactic Scale config Directory has changed to \r\n ...\\BepInEx\\config\\GalacticScale \r\nThis is to prevent data being lost when updating using the mod manager.\r\n".Translate();
             }
 
             if (!Directory.Exists(DataDir)) Directory.CreateDirectory(DataDir);

--- a/GalacticScale2/Scripts/GalacticScale2.0/SettingsUI/MainSettings.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/SettingsUI/MainSettings.cs
@@ -85,12 +85,12 @@ namespace GalacticScale
             DebugOptions.Add(GSUI.Checkbox("Force Rare Spawn".Translate(), false, "Force Rare Spawn", null, "Ignore randomness/distance checks".Translate()));
             _cheatModeCheckbox = DebugOptions.Add(GSUI.Checkbox("Cheat Mode".Translate(), false, "Cheat Mode", null, "All Research, TP by ctrl-click nav arrow".Translate()));
             DebugOptions.Add(GSUI.Slider("Ship Speed Multiplier".Translate(), 1f, 1f, 100f, "Logistics Ship Multi", null, "Multiplier for Warp Speed of Ships".Translate()));
-            Options.Add(GSUI.Group("Debug Options", DebugOptions, "Useful for testing galaxies/themes".Translate()));
+            Options.Add(GSUI.Group("Debug Options".Translate(), DebugOptions, "Useful for testing galaxies/themes".Translate()));
             var JsonOptions = new GSOptions();
             JsonOptions.Add(GSUI.Input("Export Filename".Translate(), "My First Custom Galaxy", "Export Filename", null, "Excluding .json".Translate()));
             JsonOptions.Add(GSUI.Checkbox("Minify Exported JSON".Translate(), false, "Minify JSON", null, "Only save changes".Translate()));
             _exportButton = JsonOptions.Add(GSUI.Button("Export Custom Galaxy".Translate(), "Export".Translate(), ExportJsonGalaxy, null, "Save Galaxy to File".Translate()));
-            Options.Add(GSUI.Group("Custom Galaxy Export", JsonOptions, "Usable once in game".Translate()));
+            Options.Add(GSUI.Group("Custom Galaxy Export".Translate(), JsonOptions, "Usable once in game".Translate()));
         }
 
         public void SetResourceMultiplier(float val)
@@ -117,7 +117,7 @@ namespace GalacticScale
         public void InitThemePanel()
         {
             var externalThemesGroupOptions = new List<GSUI>() {
-                GSUI.Button("Export All Themes".Translate(), "Export", ExportAllThemes)
+                GSUI.Button("Export All Themes".Translate(), "Export".Translate(), ExportAllThemes)
             };
             // GS2.Warn("ExternalThemeNames");
             // GS2.WarnJson(ExternalThemeNames);
@@ -183,7 +183,7 @@ namespace GalacticScale
                 }
             }
 
-            var externalThemesGroup = Options.Add(GSUI.Group("External Themes", externalThemesGroupOptions));
+            var externalThemesGroup = Options.Add(GSUI.Group("External Themes".Translate(), externalThemesGroupOptions));
         }
         private void ExportAllThemes(Val o)
         {


### PR DESCRIPTION
Hi!
I added Translate(), which was missing from the settings screen and Init messages.
To give what it looks like, I've attached a screen image of the translated version in Japanese.

![20210811152750_1](https://user-images.githubusercontent.com/69208466/128980628-ceb273c4-1b9c-4ab4-925e-ff8b692e814f.jpg)
