### PR TITLE
thunderstore.toml: add nebula api as a dependency

### DIFF
--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -11,6 +11,7 @@ containsNsfwContent = false
 
 [package.dependencies]
 "xiaoye97-BepInEx" = "5.4.17"
+"nebula-NebulaMultiplayerModApi" = "1.1.2"
 
 [build]
 icon = "./Package/icon.png"


### PR DESCRIPTION
until the hard dependency can be removed the nebula api should be marked as a dependency on thunderstore so that r2modman auto downloads it