### PR TITLE
fix phase through small planets when orbit is very close to a bigger planet

### DIFF
--- a/GalacticScale2/Scripts/GalacticScale2.0/Patches/GameData/GetNearestStarPlanet.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/Patches/GameData/GetNearestStarPlanet.cs
@@ -1,121 +1,36 @@
-﻿//using HarmonyLib;
+﻿/*
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
 
-//namespace GalacticScale {
-//    public partial class PatchOnGameData {
-//		public static string status = "Start";
-//		public static string lastStatus = "";
-//		private static void LogStatus()
-//        {
-//			if (status == lastStatus) return;
-//			lastStatus = status;
-//			GS2.Warn($"Current Status:{status}");
-//		}
-//		[HarmonyPrefix, HarmonyPatch(typeof(GameData), "GetNearestStarPlanet")]
-//		public static bool GetNearestStarPlanet(ref GameData __instance, ref StarData nearestStar, ref PlanetData nearestPlanet)
-//		{
-//			//if (GS2.Vanilla) return true;
-//			//if (GS2.IsMenuDemo) return true;
-//			////GS2.Warn("GNSP");
-//			//if (__instance.mainPlayer == null)
-//			//{
-//			//	GS2.Warn("Mainplayer null");
-//			//	nearestStar = null;
-//			//	nearestPlanet = null;
-//			//	status = "Error: MainPlayer Null";
-//			//}
-//			//if (nearestStar != null && GS2.GetGSStar(nearestStar).Decorative)
-//			//{
-//			//	GS2.Log($"Nullifying Decorative Star: {nearestStar.name}");
-//			//	nearestStar = null;
-//			//	status = "Looking for star";
-//			//}
-//			//double num2 = 900.0;
-//			if (nearestStar != null) //ensure star still local
-//			{
-//				double magnitude = (__instance.mainPlayer.uPosition - nearestStar.uPosition).magnitude;
-//				//num = 3600000.0;
-//				//GS2.Warn($"nearestStar != null Checking System Radius:{nearestStar.systemRadius} magnitude:{magnitude}");
-//				status = "Looking for planet";
-//				double transitionDistance = (nearestStar.systemRadius + 2) * 40000; // Leave star 2AU from last planet.
-//				if (magnitude > transitionDistance)
-//				{
-//					//nearestStar = null;
-//					GS2.Log($"At {((magnitude/40000)-2)}AU, Leaving Star {nearestStar.name}");
-//					status = "Looking for star";
-//					GameMain.data.LeaveStar();
-//				}
-//			}
-//			if (nearestPlanet != null) //ensure planet still local
-//			{
+namespace GalacticScale {
 
-//				//GS2.Warn($"nearestPlanet != null {nearestPlanet.name}");
-//				double num3 = (__instance.mainPlayer.uPosition - nearestPlanet.uPosition).magnitude - (double)nearestPlanet.realRadius;
-//				double num2 = 1000.0; // Default is 1000.
-//				status = $"Near Planet {nearestPlanet.name}";
-//				if (num3 > num2 * 0.4f)
-//				{
-//					GS2.Warn("Looking for planet");
-//					nearestPlanet = null;
-//				}
-//			}
-//			if (nearestStar == null) //Find Local Star
-//			{
-//				status = "Looking for star"; 
-//                for (int i = 0; i < __instance.galaxy.starCount; i++) // Go through every star
-//				{
-//					if (__instance.galaxy.stars[i].planetCount == 0)
-//					{
-//						GS2.Warn("Ignoring empty star"); 
-//						continue;
-//					}
-//					if (GS2.GetGSStar(__instance.galaxy.stars[i].id).Decorative)
-//					{
-//						GS2.Warn("Ignoring Decorative Star");
-//						continue; //Ignore Decorative Stars
-//					}
-//					double distanceToStar = (__instance.mainPlayer.uPosition - __instance.galaxy.stars[i].uPosition).magnitude; //Get the distance between you and the star
-//                    double transitionRadius = (__instance.galaxy.stars[i].systemRadius + 2) * 40000;
-//                    if (distanceToStar < transitionRadius)
-//					{
+    [HarmonyPatch(typeof(GameData))]
+    public partial class PatchOnGameData {
 
-//						nearestStar = __instance.galaxy.stars[i];
-//						GS2.Log($"At {((distanceToStar / 40000) - 2)}AU, Approaching Star {nearestStar.name}");
-//						status = "Looking for planet";
-//						if (!nearestStar.loaded && GameMain.isRunning)
-//						{
-//							GS2.Warn($"Loading nearestStar {nearestStar.name}");
-//							nearestStar.Load();
-//						}
-//					}
-//                }
-//			}
-//			if (__instance.mainPlayer.warping)
-//			{
-//				nearestPlanet = null;
-//				return false;
-//			}
-//			if (nearestPlanet == null) //Find Local Planet
-//			{
-//				//GS2.Warn($"Looking for nearestplanet for star {nearestStar?.name}");
-//				status = "Looking for planet";
-//				double num5 = 1000;
-//				int num6 = 0;
-//				while (nearestStar != null && num6 < nearestStar.planetCount)
-//				{
-//					double num7 = (__instance.mainPlayer.uPosition - nearestStar.planets[num6].uPosition).magnitude - (double)nearestStar.planets[num6].realRadius;
-//					if (num7 < num5)
-//					{
-//						nearestPlanet = nearestStar.planets[num6];
-//						num5 = num7;
-//					}
-//					num6++;
-//				}
-//			}
-//			LogStatus();
-//			return false;
-//		}
+        delegate void printInfo(ref StarData nearestStar, int pIndex, double num7);
 
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(GameData.GetNearestStarPlanet))]
+        public static IEnumerable<CodeInstruction> GetNearestStarPlanet_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            CodeMatcher matcher = new CodeMatcher(instructions)
+                .MatchForward(true,
+                    new CodeMatch(i => i.opcode == OpCodes.Callvirt && ((MethodInfo)i.operand).Name == "get_realRadius"),
+                    new CodeMatch(OpCodes.Conv_R8),
+                    new CodeMatch(OpCodes.Sub),
+                    new CodeMatch(OpCodes.Stloc_S))
+                .InsertAndAdvance(new CodeInstruction(OpCodes.Ldarg_1))
+                .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_S, 7))
+                .InsertAndAdvance(new CodeInstruction(OpCodes.Ldloc_S, 8))
+                .Insert(HarmonyLib.Transpilers.EmitDelegate<printInfo>((ref StarData nearestStar, int pIndex, double num7) =>
+                {
+                    GS2.Warn($"{nearestStar?.planets[pIndex].displayName} is {num7} away");
+                }));
+            return matcher.InstructionEnumeration();
+        }
 
-//	}
-//}
-
+	}
+}
+*/

--- a/GalacticScale2/Scripts/GalacticScale2.0/Utils/HandleLocalStarPlanets.cs
+++ b/GalacticScale2/Scripts/GalacticScale2.0/Utils/HandleLocalStarPlanets.cs
@@ -164,11 +164,19 @@ namespace GalacticScale
             for (var i = 0; closestStar != null && closestPlanet == null && i < closestStar.planetCount; i++)
             {
                 var planet = closestStar.planets[i];
+                double dist = 1000f;
+                /*
                 if (DistanceTo(planet) < TransisionDistance(planet))
                 {
                     // GS2.Log($"Switching to {planet.name}");
                     closestPlanet = planet;
                     break;
+                }
+                */
+                if(DistanceTo(planet) < dist)
+                {
+                    closestPlanet = planet;
+                    dist = DistanceTo(planet);
                 }
             }
         }


### PR DESCRIPTION
Basically uses the games logic to determine the nearest planet. Seems to solve the issue but im not sure why this was changed in the first place. Maybe breaks other stuff regarding determining the nearest planet?