### PR TITLE
Fix logistic vessel pathfinding near huge stars

### DIFF
--- a/Scripts/Patches/StationComponent/InternalTickRemote.cs
+++ b/Scripts/Patches/StationComponent/InternalTickRemote.cs
@@ -9,6 +9,10 @@ namespace GalacticScale
 {
     public class PatchOnStationComponent
     {
+        // Two patches being made to StationComponent.InternalTickRemote:
+        // 1. Allow logistics vessels to path in systems up to 99 astrobodies, up from 10.
+        // 2. Allow logistics vessels to get much closer to stars, rather than staying 2.5x radius away.
+        //    Makes planets near huge stars reachable by ship.
         // [HarmonyDebug]
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(StationComponent), "InternalTickRemote")]
@@ -16,7 +20,6 @@ namespace GalacticScale
         {
             var codeMatcher = new CodeMatcher(instructions, il).MatchForward(false,
                 new CodeMatch(op => op.opcode == OpCodes.Ldc_I4_S && op.OperandIs(10))); // Search for ldc.i4.s 10
-
             if (codeMatcher.IsInvalid)
             {
                 GS2.Error("InternalTickRemote Transpiler Failed");
@@ -25,6 +28,18 @@ namespace GalacticScale
             instructions = codeMatcher.Repeat(z => z // Repeat for all occurences 
                    .Set(OpCodes.Ldc_I4_S, 99)) // Replace operand with 99
                 .InstructionEnumeration();
+
+            codeMatcher = new CodeMatcher(instructions, il).MatchForward(false,
+                new CodeMatch(op => op.opcode == OpCodes.Ldc_R4 && op.OperandIs(2.5f))); // Search for ldc.r4 2.5f
+            if (codeMatcher.IsInvalid)
+            {
+                GS2.Error("InternalTickRemote 2nd Transpiler Failed");
+                return instructions;
+            }
+            instructions = codeMatcher.Repeat(z => z // Repeat for all occurences
+                   .Set(OpCodes.Ldc_R4, 1.0f)) // Replace operand with 1.0f
+                .InstructionEnumeration();
+
             return instructions;
         }
     }


### PR DESCRIPTION
This PR allows logistics vessels to get much closer to stars. The original `StationComponent.InternalTickRemote` code tries to navigate logistics vessels around astrobodies rather than going straight through. That code multiplies star radius by 2.5x, which I think is just because that visually looked better with the default star sizes.

GalacticScale has much larger stars, and very often planets are within 2.5x the star radius. Logistics vessels behave very badly when that happens. So this code disables the 2.5x multiplier, changing it to 1.0x. In my testing ships still stay a good distance above the star surface, so it still looks good.

This is the first transpiler patch I've written, apologies if the code isn't great.