### PR TITLE
Fix IndexOutOfRange Error on Exit

### DIFF
--- a/Scripts/SettingsUI/SettingsUI.cs
+++ b/Scripts/SettingsUI/SettingsUI.cs
@@ -74,12 +74,26 @@ namespace GalacticScale
             var newTabTexts = __instance.tabTexts.AddToArray(galacticButton.GetComponentInChildren<Text>());
             __instance.tabTexts = newTabTexts;
 
+            //DSP expects the same number of tabButtons and revertButtons. Otherwise will throw an IndexOutOfRange exception on exit.
+            //See UIOptionWindow._OnRegEvent()
+            var revertButtons = __instance.revertButtons;
+            var revertButton = details.Find("revert-button").GetComponent<RectTransform>();
+            revertButton.gameObject.SetActive(false); // Revert function not implemented, so hide for now.
+            var newRevertButtons = revertButtons.AddToArray(revertButton.GetComponent<UIButton>());
+            __instance.revertButtons = newRevertButtons;
 
             var languageCombo = details.Find("language").GetComponent<RectTransform>();
             anchorX = languageCombo.anchoredPosition.x;
             anchorY = languageCombo.anchoredPosition.y;
-            while (details.transform.childCount > 0)
-                Object.DestroyImmediate(details.transform.GetChild(0).gameObject);
+
+            //Remove everything except for the placeholder revert button
+            foreach (RectTransform child in details)
+            {
+                if (child != revertButton)
+                {
+                    Object.Destroy(child.gameObject);
+                }
+            }
 
             ImportCustomGeneratorOptions();
             CreateOptionsUI();


### PR DESCRIPTION
If you open the GS settings UI at any point, then exit the game, DSP will throw an IndexOutOfRange exception before closing.  DSP expects there to be the same number of revert buttons as tabs, but GS does not include one, so the error is thrown when it tries to unload/destroy GS's revert button. This doesn't have any real negative effects, but red text is bad.

This change adds a revert button (cloned from the revert buttons on the bottom left corner of all other tabs) and hides it, just to make DSP happy. Maybe at some point it could replace the "Reset Now" button's functionality.

Code is mostly [inspired/borrowed/copied from Nebula](https://github.com/hubastard/nebula/blob/ee63b660214605864ca23ce91ddef0072dd63a6e/NebulaPatcher/Patches/Dynamic/UIOptionWindow_Patch.cs#L104)