### PR TITLE
Fix mk2 miner effect

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -62,6 +62,7 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PatchOnBuildTool_Inserter));
                 harmony.PatchAll(typeof(PatchOnBuildTool_Path));
                 harmony.PatchAll(typeof(PatchOnBuildTool_PathAddon));
+                harmony.PatchAll(typeof(PatchOnFactoryModel));
                 harmony.PatchAll(typeof(PatchOnGameAbnormalityData));
                 harmony.PatchAll(typeof(PatchOnGameAchievementData));
                 harmony.PatchAll(typeof(PatchOnGameData));

--- a/Scripts/Init.cs
+++ b/Scripts/Init.cs
@@ -196,6 +196,7 @@ namespace GalacticScale
             // Warn("Step8");
             UpdateNebulaSettings();
             // Warn("Step9");
+            Utils.InitMk2MinerEffectVertices();
         }
     }
 }

--- a/Scripts/Patches/FactoryModel/AdjustMk2MiningEffect.cs
+++ b/Scripts/Patches/FactoryModel/AdjustMk2MiningEffect.cs
@@ -1,0 +1,36 @@
+﻿using HarmonyLib;
+
+namespace GalacticScale
+{
+    public class PatchOnFactoryModel
+    {
+        /// <summary>
+        /// The mining effect that appears on veins when actively mined by an Advanced Miner are hardcoded for 200 radius planets in the shader.
+        /// To compensate for the this, adjust the Y values on the model vertices themselves by the difference in planet radius.
+        /// Adjust each time a planet is loaded since the mesh is shared globally, but each planet can be a different radius.
+        /// </summary>
+        /// <param name="__instance"></param>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(FactoryModel), "InitCollectorMaterial")]
+        public static void AdjustMk2MiningEffect(ref FactoryModel __instance)
+        {
+            const float standardRadius = 200f;
+            const float standardPlanetCurveOffset = 0.3f;
+
+            var realRadius = __instance.planet.realRadius;
+            if (realRadius == standardRadius) return;
+
+            var adjustVertexY = realRadius - standardRadius;
+
+            // veins at the far end of the miner are lower due to the curve of the planet. Adjust this offset a bit so the effect appears closer to where it should.
+            // Between 0.1 and 0.9. Anything above 0.9 clips above the the top glass.
+            var planetCurveOffset = (uint)(90.0f / realRadius * 10.0f) / 10.0f;
+            planetCurveOffset = planetCurveOffset > 0.9 ? 0.9f : planetCurveOffset;
+            adjustVertexY += planetCurveOffset - standardPlanetCurveOffset;
+
+            if (!Utils.AdjustMk2MinerEffectVertices(adjustVertexY))
+                GS2.Error("Failed to adjust mining effect for planet.");
+
+        }
+    }
+}

--- a/Scripts/Patches/FactoryModel/AdjustMk2MiningEffect.cs
+++ b/Scripts/Patches/FactoryModel/AdjustMk2MiningEffect.cs
@@ -14,12 +14,12 @@ namespace GalacticScale
         [HarmonyPatch(typeof(FactoryModel), "InitCollectorMaterial")]
         public static void AdjustMk2MiningEffect(ref FactoryModel __instance)
         {
+            if (GS2.Vanilla) return;
+
             const float standardRadius = 200f;
             const float standardPlanetCurveOffset = 0.3f;
 
             var realRadius = __instance.planet.realRadius;
-            if (realRadius == standardRadius) return;
-
             var adjustVertexY = realRadius - standardRadius;
 
             // veins at the far end of the miner are lower due to the curve of the planet. Adjust this offset a bit so the effect appears closer to where it should.


### PR DESCRIPTION
Fixes the the mining effect that appears when Advanced Miners are running by adjusting the y-axis value on vertices in the effect model to compensate for the non-200 planet radius. Each time local planet changes and FactoryModel is loaded, it will re-adjust the model with the new planet radius.

Initial values of model vertices are saved in Utils. InitMk2MinerEffectVertices() which is called in GS2.Init(). Model vertices are adjusted when InitCollectorMaterial() is called by FactoryModel.Init() on planet load.

If it's possible for multiple FactoryModels to be active at once, this will break. As far as I can tell, that's not possible. If that's an issue, could add a check for local planet.