### PR TITLE
add multithreading to UpdatePoses

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -63,6 +63,7 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PatchOnBuildTool_Path));
                 harmony.PatchAll(typeof(PatchOnBuildTool_PathAddon));
                 harmony.PatchAll(typeof(PatchOnFactoryModel));
+                harmony.PatchAll(typeof(PatchOnGalaxyData));
                 harmony.PatchAll(typeof(PatchOnGameAbnormalityData));
                 harmony.PatchAll(typeof(PatchOnGameAchievementData));
                 harmony.PatchAll(typeof(PatchOnGameData));

--- a/Scripts/Patches/GalaxyData/UpdatePoses.cs
+++ b/Scripts/Patches/GalaxyData/UpdatePoses.cs
@@ -1,0 +1,43 @@
+﻿using HarmonyLib;
+using System;
+using System.Threading.Tasks;
+
+namespace GalacticScale
+{
+    public class PatchOnGalaxyData
+    {
+        /// <summary>
+        /// Only beneficial for >64 stars because of the overhead involved in creating threads.
+        /// 
+        /// Reads/Writes in UpdateRuntimePose to values outside of the PlanetData instance:
+        /// orbitAroundPlanet.runtimePosition (read) - Parallel per star, so if this worked before, it should work now.
+        /// orbitAroundPlanet.runtimePositionNext (read) - Parallel per star, so if this worked before, it should work now.
+        /// star.uPosition (read) - Parallel per star, so if this worked before, it should work now.
+        /// galaxy.astrosData[id].uPos (write) - Multiple threads writing to astrosData simultaneously, but each planet is only writing to its own portion of the array.
+        /// galaxy.astrosData[id].uRot (write) - Multiple threads writing to astrosData simultaneously, but each planet is only writing to its own portion of the array.
+        /// galaxy.astrosData[id].uPosNext (write) - Multiple threads writing to astrosData simultaneously, but each planet is only writing to its own portion of the array.
+        /// galaxy.astrosData[id].uRotNext (write) - Multiple threads writing to astrosData simultaneously, but each planet is only writing to its own portion of the array.
+        /// No locking needed in UpdateRuntimePose.
+        /// </summary>
+        /// <param name="time"></param>
+        /// <param name="__instance"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(GalaxyData), "UpdatePoses")]
+        public static bool UpdatePoses(Double time, GalaxyData __instance)
+        {
+            if (MultithreadSystem.usedThreadCntSetting < 2 || __instance.starCount <= 64) return true;
+            Parallel.For(0, __instance.starCount, new ParallelOptions {MaxDegreeOfParallelism = MultithreadSystem.usedThreadCntSetting},
+                (i) =>
+                {
+                    for (var j = 0; j < __instance.stars[i].planetCount; j++)
+                    {
+                        __instance.stars[i].planets[j].UpdateRuntimePose(time);
+                    }
+                }
+
+            );
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Adds multithreading per star to UpdatePoses so that PlanetData.UpdateRuntimePoses can run on a very large number of planets much quicker. Threading is per star to avoid any conflicts between moons and their parent planets.

Threading implemented using Parallel.For, not the standard multithreading system DSP uses for most everything else. Mostly because it was very easy to implement on an existing for loop, didn't make things worse for >64 star galaxies, and had a pretty sizable impact on 256 stars and up: 2-4ms (7-15 ups) faster.

If a galaxy has 64 stars or less, this patch is skipped.