### PR TITLE
Fix fastTravelButton & PlanetFactory.veinGroups[0]

### DIFF
--- a/Scripts/Patches/PlanetFactory/FlattenTerrain.cs
+++ b/Scripts/Patches/PlanetFactory/FlattenTerrain.cs
@@ -5,7 +5,7 @@ using HarmonyLib;
 
 namespace GalacticScale
 {
-    public static class PatchOnPlanetFactory
+    public static partial class PatchOnPlanetFactory
     {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(PlanetFactory), "InitVeinGroups", typeof(PlanetData))]

--- a/Scripts/Patches/PlanetFactory/RemoveEmptyVeinGroups.cs
+++ b/Scripts/Patches/PlanetFactory/RemoveEmptyVeinGroups.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using HarmonyLib;
+
+namespace GalacticScale
+{
+    public static partial class PatchOnPlanetFactory
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(PlanetFactory), "RemoveEmptyVeinGroups")]
+        public static bool RemoveEmptyVeinGroups(PlanetFactory __instance)
+        {
+            if (__instance.veinGroups[0].count <= 0) return true;
+
+			GS2.Warn("Reassign veinGroup at position 0: " + __instance.veinGroups[0].ToString());
+			for (int i = 1; i < __instance.veinGroups.Length; i++)
+                if (__instance.veinGroups[i].count <= 0)  __instance.veinGroups[i].SetNull();
+
+			// Modify ArrangeVeinGroups which maps veinGroup at index-0 to other positive location
+			int oldLength = __instance.veinGroups.Length;
+			if (__instance.tmp_vein_group_idx_mapping == null || __instance.tmp_vein_group_idx_mapping.Length < oldLength)
+				__instance.tmp_vein_group_idx_mapping = new int[oldLength * 2];
+			int[] array = __instance.tmp_vein_group_idx_mapping;
+			Array.Clear(array, 0, array.Length);
+			int newLength = 1;
+			for (int i = 1; i < oldLength; i++)
+			{
+				if (__instance.veinGroups[i].isNull) 
+					array[i] = 0;
+				else
+				{
+					if (i > newLength) __instance.veinGroups[newLength] = __instance.veinGroups[i];
+					array[i] = newLength;
+					newLength++;
+				}
+			}
+
+			Array sourceArray = __instance.veinGroups;
+			__instance.veinGroups = new VeinGroup[++newLength]; // make extra space for 0
+			Array.Copy(sourceArray, __instance.veinGroups, Math.Min(newLength, oldLength));
+			array[0] = newLength - 1; // remap 0 to the last element
+			__instance.veinGroups[newLength - 1] = __instance.veinGroups[0];
+			__instance.veinGroups[0].SetNull();
+			for (int j = 1; j < __instance.veinCursor; j++)
+			{
+				if (__instance.veinPool[j].id == j)
+				{
+					int groupIndex = array[__instance.veinPool[j].groupIndex];
+					__instance.veinPool[j].groupIndex = (short)groupIndex;
+					if (__instance.veinGroups[groupIndex].type == EVeinType.None)
+					    __instance.veinGroups[groupIndex].type = __instance.veinPool[j].type;
+				}
+			}
+			return false;
+        }
+    }
+}

--- a/Scripts/Patches/UIStarmap/UpdateCursorView.cs
+++ b/Scripts/Patches/UIStarmap/UpdateCursorView.cs
@@ -19,15 +19,19 @@ namespace GalacticScale
                 uistarmapPlanet = __instance.focusPlanet;
                 uistarmapStar = null;
                 __instance.cursorFunctionGroup.SetActive(true);
+                bool active2 = GameMain.sandboxToolsEnabled && GameMain.mainPlayer.planetId != __instance.focusPlanet.planet.id && !GameMain.mainPlayer.warping;
+                __instance.fastTravelButton.gameObject.SetActive(active2);
                 var planetPin = GameMain.history.GetPlanetPin(__instance.focusPlanet.planet.id);
                 __instance.cursorFunctionIcon1.localEulerAngles = new Vector3(0f, 0f, planetPin == EPin.Show ? -90 : planetPin == EPin.Hide ? 90 : 0);
                 __instance.cursorFunctionText1.text = (planetPin == EPin.Show ? "天体显示标签" : planetPin == EPin.Hide ? "天体隐藏标签" : "天体自动标签").Translate();
+                __instance.fastTravelButton.button.interactable = !__instance.fastTravelling;
             }
             else if (__instance.focusStar != null)
             {
                 uistarmapPlanet = null;
                 uistarmapStar = __instance.focusStar;
                 __instance.cursorFunctionGroup.SetActive(true);
+                __instance.fastTravelButton.gameObject.SetActive(false);
                 var starPin = GameMain.history.GetStarPin(__instance.focusStar.star.id);
                 __instance.cursorFunctionIcon1.localEulerAngles = new Vector3(0f, 0f, starPin == EPin.Show ? -90 : starPin == EPin.Hide ? 90 : 0);
                 __instance.cursorFunctionText1.text = (starPin == EPin.Show ? "天体显示标签" : starPin == EPin.Hide ? "天体隐藏标签" : "天体自动标签").Translate();
@@ -35,6 +39,7 @@ namespace GalacticScale
             else
             {
                 __instance.cursorFunctionGroup.SetActive(false);
+                __instance.fastTravelButton.gameObject.SetActive(false);
             }
 
             if (uistarmapPlanet != null) uistarmapStar = null;


### PR DESCRIPTION
- Fix fastTravelButton appearing even if sandbox mode is not enabled
- Fix invisible veinGroup in planet detail / vein detail which are cause by veinGroup that is assigned in position-0. 
TODO: Make sure vein generation algo won't generate veinGroup at position 0.