### PR TITLE
Fix hive not attacking when player got close

### DIFF
--- a/Scripts/Patches/-Debug/Debug.cs
+++ b/Scripts/Patches/-Debug/Debug.cs
@@ -474,6 +474,7 @@ namespace GalacticScale
                             var orbit = ra.ItemAndRemove(possibleOrbits);
                             Warn($"New Orbit Radius = {orbit}");
                             enemyDFHiveSystem2.hiveAstroOrbit.orbitRadius = orbit;
+							enemyDFHiveSystem2.orbitRadius = orbit * 40000f; // Convert from AU to m
                         }
                         
 


### PR DESCRIPTION
The issue happened because when the mod relocated a hive due to orbit radius being bigger than the system radius, it didn't update the EnemyDFHiveSystem's orbit radius as well, so in SensorLogic(), the hive was using it's old position and comparing to the player to see if the player was in attack range.