### PR TITLE
Fix IndexOutOfRangeException pasting foundation blueprints on GS2 planets (game 0.10.34)

### DIFF
--- a/Scripts/Patches/BuildTool_BlueprintPaste/CalculateReformData.cs
+++ b/Scripts/Patches/BuildTool_BlueprintPaste/CalculateReformData.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace GalacticScale
+{
+    public partial class PatchOnBuildTool_BlueprintPaste
+    {
+        // Game 0.10.34 added foundation data to blueprints. BuildTool_BlueprintPaste.CalculateReformData
+        // walks the whole previewReform buffer (sized by platformSystem.maxReformCount) while stepping a
+        // latitude-band index through platformSystem.reformOffsets with no bounds check.
+        //
+        // GS2's ComputeMaxReformCount prefix sets maxReformCount from the keyed-LUT total
+        // (sum of segCount * 25 * 2), which can exceed the cumulative total reformOffsets was built
+        // from, so on GS2 planets the band index runs off the end of the table and the game throws
+        // IndexOutOfRangeException on every tick of the paste preview (and disables autosave).
+        //
+        // Cells beyond the reformOffsets total are always zero and are skipped by the walk, so clamping
+        // the read is behavior-preserving: int.MaxValue out of range just stops further band advances.
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(BuildTool_BlueprintPaste), "CalculateReformData")]
+        public static IEnumerable<CodeInstruction> CalculateReformData(IEnumerable<CodeInstruction> instructions)
+        {
+            var clampedGet = AccessTools.Method(typeof(PatchOnBuildTool_BlueprintPaste), nameof(ClampedIntArrayGet));
+            foreach (var ins in instructions)
+            {
+                if (ins.opcode == OpCodes.Ldelem_I4)
+                {
+                    var call = new CodeInstruction(OpCodes.Call, clampedGet);
+                    call.labels.AddRange(ins.labels);
+                    call.blocks.AddRange(ins.blocks);
+                    yield return call;
+                }
+                else
+                {
+                    yield return ins;
+                }
+            }
+        }
+
+        public static int ClampedIntArrayGet(int[] arr, int idx)
+        {
+            if (arr != null && idx >= 0 && idx < arr.Length) return arr[idx];
+            return int.MaxValue;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #272

## Problem

Since game version 0.10.34 (which added foundation data to blueprints), pasting a blueprint that carries foundations on a GS2 planet throws this on every tick of the paste preview, pops the game's Runtime Error dialog, and disables autosave for the session:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
  at BuildTool_BlueprintPaste.CalculateReformData () [0x007de]
  at BuildTool_BlueprintPaste.OperatingPrestage () [0x000ee]
  at BuildTool_BlueprintPaste._OnTick (System.Int64 time) [0x0005b]
  at BuildTool._GameTick (System.Int64 time) [0x000cf]
```

Reproduced on 0.10.34.28529 with GS2 2.77.3.

## Root cause

`PatchOnPlatformSystem.ComputeMaxReformCount` builds `reformOffsets` cumulatively from `DetermineLongitudeSegmentCount(...) * 5` per latitude row, but then overrides `maxReformCount` with the keyed-LUT total (`sum of segCount * 25 * 2`). On GS2 planet sizes these two formulas can disagree, so buffers sized by `maxReformCount` (`reformData`, and the game's `previewReform`) extend past the range that `reformOffsets` covers.

That mismatch was latent for years because nothing walked the buffer linearly. The new `CalculateReformData` does: it iterates `0..previewReform.Length` while stepping a latitude-band index through `reformOffsets` with no bounds check, so the band index runs off the end of the table.

## Fix

A transpiler on `BuildTool_BlueprintPaste.CalculateReformData` that replaces the raw `ldelem.i4` loads with a bounds-clamped read returning `int.MaxValue` when out of range, which simply stops further band advances. The cells beyond the `reformOffsets` total are always zero and are already skipped by the walk, so this is behavior-preserving — it only removes the crash.

Deliberately does **not** touch the array sizing: `PatchOnPlatformSystem.GetReformType` intentionally grows `reformData` to the LUT size, and reform arrays persist in saves, so "fixing" the `maxReformCount`/`reformOffsets` disagreement directly would risk breaking existing saves and the other patches that depend on the larger buffer.

## Testing

- Verified the transpiled IL (all 8 `ldelem.i4` in the method replaced) via a standalone Harmony harness against the 0.10.34.28529 `Assembly-CSharp.dll`.
- In game (0.10.34.28529 + GS2 2.77.3 + this patch): pasting a foundation-carrying blueprint on a GS2 planet no longer throws; buildings and foundations both place correctly. Without the patch, same blueprint/planet crashes as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
