### PR TITLE
Reset theme proto table to a runtime-captured baseline (removes hardcoded 128 cap, fixes stale dataIndices)

### DIFF
--- a/Scripts/Galaxy Generation/ProcessGalaxy.cs
+++ b/Scripts/Galaxy Generation/ProcessGalaxy.cs
@@ -6,9 +6,33 @@ namespace GalacticScale
 {
     public static partial class GS2
     {
+        // Length of LDB._themes before GS2 ever appended a theme proto: vanilla themes plus
+        // anything other mods registered at load. Captured on the first ProcessGalaxy call and
+        // used as the reset point for the theme table between generations, replacing the old
+        // hardcoded 128 (which silently truncated real themes once vanilla+mods crossed it, and
+        // left stale dataIndices entries pointing past the shortened array).
+        private static int builtinThemeCount = -1;
+
+        private static void ResetThemeProtoSet()
+        {
+            var themes = LDB._themes;
+            if (themes?.dataArray == null || builtinThemeCount < 0 || themes.dataArray.Length <= builtinThemeCount) return;
+            var staleIds = new System.Collections.Generic.List<int>();
+            foreach (var kv in themes.dataIndices)
+                if (kv.Value >= builtinThemeCount)
+                    staleIds.Add(kv.Key);
+            foreach (var id in staleIds) themes.dataIndices.Remove(id);
+            Array.Resize(ref themes.dataArray, builtinThemeCount);
+        }
+
         public static GalaxyData ProcessGalaxy(GameDesc desc, bool sketchOnly = false)
         {
             Log($"Start ProcessGalaxy:{sketchOnly} StarCount:{gameDesc.starCount} Seed:{gameDesc.galaxySeed} Called By{GetCaller()}. Galaxy StarCount : {galaxy?.stars?.Length}");
+            if (builtinThemeCount < 0 && LDB._themes?.dataArray != null)
+            {
+                builtinThemeCount = LDB._themes.dataArray.Length;
+                Log($"Captured builtin theme table size: {builtinThemeCount}");
+            }
             var random = new Random(GSSettings.Seed);
             try
             {
@@ -25,7 +49,7 @@ namespace GalacticScale
                     // Log("Start");
                     GSSettings.Reset(gameDesc.galaxySeed);
                     // Warn(LDB._themes.dataArray.Length.ToString());
-                    if (LDB._themes.dataArray != null && LDB._themes.dataArray.Length > 128) Array.Resize(ref LDB._themes.dataArray, 128);
+                    ResetThemeProtoSet();
                     // Warn(LDB._themes.dataArray.Length.ToString());
                     // GS2.LogJson(gameDesc);
                     // GS2.Warn(gameDesc.resourceMultiplier.ToString());


### PR DESCRIPTION
## Problem

`ProcessGalaxy` resets the theme proto table between generations with a hardcoded cap:

```csharp
if (LDB._themes.dataArray != null && LDB._themes.dataArray.Length > 128) Array.Resize(ref LDB._themes.dataArray, 128);
```

Two failure modes hide in this line:

1. **The 128 assumption.** The moment vanilla themes plus anything registered by *other* mods (LDBTool users, theme packs) exceeds 128, the trim starts eating real `ThemeProto`s — the in-repo warning string about DSP "adding additional planet themes and their new subtheme system" suggests the base game is already growing in that direction.
2. **`dataIndices` is never cleaned.** Trimming the array leaves stale id → index entries pointing past the new end. Any later lookup of one of those ids (`ThemeProtoSet.Select`, a planet referencing a theme from a previous generation/loaded save) is an `IndexOutOfRangeException`. This may be the mechanism behind #260 (planets with extra biomes failing to load).

## Fix

Capture the table length on the **first** `ProcessGalaxy` call — vanilla themes plus whatever other mods registered at load — and reset to that runtime baseline instead of any constant:

- remove every `dataIndices` entry whose index is ≥ the baseline, then resize the array down to it;
- guarded to be a no-op when the table is already at/below baseline, so repeated calls are idempotent;
- GS2-appended themes re-register afterwards with the same length-derived ids as before, so existing galaxies and `.gs2` sidecars see identical ids — no behavior change for the normal case.

This removes the constant entirely: vanilla can grow its theme table, and other theme mods loaded before GS2's first generation are preserved instead of truncated.

## Testing

- Builds clean (`dotnet build -c Release`, 0 errors) — incidentally, the project builds fine on Linux once `UnityEngine.UI` resolves from a local path.
- Verified the compiled method's IL does exactly the above (baseline guard → collect stale ids → remove → resize).
- Deployed to a live 0.10.34.28529 install; in-game soak (repeated galaxy-select regeneration + loading an existing GS2 save) is running now — will follow up with results on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
