### PR TITLE
Make LUT construction thread-safe and deterministic (3-thread Dictionary race + first-write-wins geometry)

### DIFF
--- a/Scripts/Planet Generation/LUT Rework.cs
+++ b/Scripts/Planet Generation/LUT Rework.cs
@@ -8,17 +8,37 @@ namespace GalacticScale
     {
         public static Dictionary<int, int[]> keyedLUTs = new();
 
+        // Guards all WRITES to keyedLUTs / PatchOnUIBuildingGrid.LUT512. SetLuts is reached from
+        // the main thread (CreatePlanet, OnActivePlanetLoaded) and from the planet compute/scan
+        // threads via the DetermineLongitudeSegmentCount patches, and unsynchronized
+        // Dictionary.Add can corrupt the table or hang a concurrent reader. Reads stay lock-free:
+        // published dictionaries are never mutated again (copy-on-write below).
+        private static readonly object lutLock = new();
+
         public static void SetLuts(int segments, float planetRadius)
         {
             // GS2.Log($"{segments}, {planetRadius}");
             if (!DSPGame.IsMenuDemo && !Vanilla) // Prevent special LUT's being created in main menu
+                lock (lutLock)
             {
                 if (keyedLUTs.ContainsKey(segments) && PatchOnUIBuildingGrid.LUT512.ContainsKey(segments)) return;
+
+                // Callers disagree about planetRadius: most pass planet.radius, but the PlanetGrid
+                // patch passes the segment count as the radius (it has no planet reference). Since
+                // GS2 radii are always multiples of 10 (Utils.ParsePlanetSize) and segments =
+                // (int)(radius / 4) * 4, each segment count maps back to exactly one radius in
+                // [segments, segments + 4) - so derive it and every caller builds the identical
+                // table for a given key, instead of first-write-wins deciding the geometry.
+                var canonicalRadius = (segments + 9) / 10 * 10;
+                if (canonicalRadius < segments + 4) planetRadius = canonicalRadius;
 
                 if (segments < 4 || planetRadius < 5)
                 {
                     planetRadius = GameMain.data.localPlanet.realRadius;
-                    segments = Mathf.CeilToInt(GameMain.data.localPlanet.radius / 4f + 0.1f) * 4;
+                    // (int) truncation, not CeilToInt: must match the segment-key formula used by
+                    // CreatePlanet/OnActivePlanetLoaded or this fallback files its table under a
+                    // key nobody else looks up.
+                    segments = (int)(GameMain.data.localPlanet.radius / 4f + 0.1f) * 4;
                 }
                 var numSegments = segments / 4; //Number of segments on a quarter circle (the other 3/4 will result by mirroring)
                 var lut = new int[numSegments];
@@ -593,9 +613,14 @@ namespace GalacticScale
                     };
                 }
 
-                //Fill all Look Up Tables (Dictionaries really)
-                if (!keyedLUTs.ContainsKey(segments)) keyedLUTs.Add(segments, lut);
-                if (!PatchOnUIBuildingGrid.LUT512.ContainsKey(segments)) PatchOnUIBuildingGrid.LUT512.Add(segments, classicLUT);
+                //Fill all Look Up Tables (Dictionaries really). Publish copy-on-write: readers on
+                //other threads index these without taking lutLock, so a published dictionary must
+                //never be mutated - swap in a superset copy instead. Entries only ever accumulate,
+                //so a reader holding a stale reference just re-checks ContainsKey and lands here.
+                if (!keyedLUTs.ContainsKey(segments))
+                    keyedLUTs = new Dictionary<int, int[]>(keyedLUTs) { { segments, lut } };
+                if (!PatchOnUIBuildingGrid.LUT512.ContainsKey(segments))
+                    PatchOnUIBuildingGrid.LUT512 = new Dictionary<int, int[]>(PatchOnUIBuildingGrid.LUT512) { { segments, classicLUT } };
             }
         }
     }


### PR DESCRIPTION
## Problem

`GS2.SetLuts` writes `GS2.keyedLUTs` and `PatchOnUIBuildingGrid.LUT512` — plain `Dictionary`s — with no synchronization, but it is reached from **three threads**: the main thread (`CreatePlanet`, `OnActivePlanetLoaded`, `UIBuildingGrid.Update`) and the planet **compute** and **scan** worker threads via the patched `DetermineLongitudeSegmentCount` (invoked when `PlanetAuxData` is constructed in `Modeler.Compute`/`Modeler.Scan`). Concurrent `Dictionary.Add` during a bucket resize can corrupt the table or send a concurrent `ContainsKey` reader into an infinite loop — a plausible source of rare "game hangs while planets load in" reports.

Separately, the tables were **non-deterministic**: the `PlanetGrid` patch calls `SetLuts(segment, segment)` (it has no planet reference), while the `PlatformSystem` patches pass the real `planet.radius`. `SetLuts` is first-write-wins, and for radii **not divisible by 20** (510, 490, 130, …) the two calls build *different tables for the same key* — whichever subsystem asked first decided the planet's grid geometry for the session.

## Fix

- **Writes under a lock, published copy-on-write.** A published dictionary is never mutated again; new entries go into a superset copy that replaces the field reference atomically. All existing lock-free readers on worker threads stay exactly as they are — no signature change, no `volatile` (which would alter the field signature and break binary compatibility for pre-built third-party generator DLLs that link against `GalacticScale.dll`).
- **Radius derived from the segment key inside `SetLuts`.** GS2 radii are always multiples of 10 (`Utils.ParsePlanetSize`) and `segments = (int)(radius/4)*4`, so each segment count maps back to exactly one radius in `[segments, segments+4)`. Deriving it makes every caller build the identical table for a given key — the `(segment, segment)` call and the real-radius calls now agree by construction.
- The degenerate-input fallback now files its table under the same truncation-based key as every other caller (it used `CeilToInt`, which produced an orphan key for radii not divisible by 20).

## Verification

- Exhaustive check of the canonicalization over the whole radius domain (10–510 step 10): radius → segment key → derived radius round-trips exactly for every value, and the `(segment, segment)`-style call derives the same radius as the real-radius callers in all cases.
- Compiled IL inspected: `Monitor.Enter/Exit` wrap the build, and each table publish is a copy-construct + atomic field store.
- Builds clean (0 errors). In-game soak (galaxy generation plus flying between planets to exercise the compute/scan threads) is running on a live 0.10.34.28529 install — will follow up with results.

Second of the three latent issues found while mapping the codebase (first was #273); the remaining one is the `maxReformCount`/`reformOffsets` formula disagreement behind the crash #271 clamped, which deserves its own careful PR since reform arrays persist in saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
