### PR TITLE
Add failure guards to all unguarded transpilers (prevents silent no-ops, method corruption, and patch-cascade aborts on game updates)

### DIFF
--- a/Scripts/Patches/BuildTool_BlueprintPaste/CalculateReformData.cs
+++ b/Scripts/Patches/BuildTool_BlueprintPaste/CalculateReformData.cs
@@ -22,6 +22,7 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> CalculateReformData(IEnumerable<CodeInstruction> instructions)
         {
             var clampedGet = AccessTools.Method(typeof(PatchOnBuildTool_BlueprintPaste), nameof(ClampedIntArrayGet));
+            var patched = 0;
             foreach (var ins in instructions)
             {
                 if (ins.opcode == OpCodes.Ldelem_I4)
@@ -30,12 +31,19 @@ namespace GalacticScale
                     call.labels.AddRange(ins.labels);
                     call.blocks.AddRange(ins.blocks);
                     yield return call;
+                    patched++;
                 }
                 else
                 {
                     yield return ins;
                 }
             }
+
+            // Zero replacements is not necessarily an error (another mod's transpiler may have
+            // replaced the loads first, which is a safe no-op for us) but after a game update it
+            // can also mean the method was rewritten - worth a note in the log either way.
+            if (patched == 0)
+                GS2.Warn("BuildTool_BlueprintPaste.CalculateReformData transpiler: no int-array loads found to clamp (another mod patched them first, or a game update rewrote the method).");
         }
 
         public static int ClampedIntArrayGet(int[] arr, int idx)

--- a/Scripts/Patches/BuildTool_BlueprintPaste/CheckBuildConditions.cs
+++ b/Scripts/Patches/BuildTool_BlueprintPaste/CheckBuildConditions.cs
@@ -11,13 +11,18 @@ namespace GalacticScale
         [HarmonyPatch(typeof(BuildTool_BlueprintPaste), "CheckBuildConditions")]
         public static IEnumerable<CodeInstruction> CheckBuildConditions(IEnumerable<CodeInstruction> instructions)
         {
-            instructions = new CodeMatcher(instructions).MatchForward(true, new CodeMatch(OpCodes.Ldloc_S), new CodeMatch(OpCodes.Ldflda), new CodeMatch(OpCodes.Call), new CodeMatch(OpCodes.Ldc_R4, 200.2f)).SetInstruction(Transpilers.EmitDelegate<Func<float>>(() =>
+            var matcher = new CodeMatcher(instructions).MatchForward(true, new CodeMatch(OpCodes.Ldloc_S), new CodeMatch(OpCodes.Ldflda), new CodeMatch(OpCodes.Call), new CodeMatch(OpCodes.Ldc_R4, 200.2f));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("BuildTool_BlueprintPaste.CheckBuildConditions transpiler: 200.2f pattern not found (game update changed the method?). Returning original code - blueprint paste height checks will assume a radius-200 planet.");
+                return instructions;
+            }
+
+            return matcher.SetInstruction(Transpilers.EmitDelegate<Func<float>>(() =>
             {
                 return GameMain.localPlanet?.realRadius + 0.2f??200.2f;
                 // return planet == null ? 200.2f : planet.realRadius + 0.2f;
             })).InstructionEnumeration();
-
-            return instructions;
         }
     }
 }

--- a/Scripts/Patches/PlanetData/UpdateDirtyMesh.cs
+++ b/Scripts/Patches/PlanetData/UpdateDirtyMesh.cs
@@ -20,7 +20,9 @@ namespace GalacticScale
             var codes = new List<CodeInstruction>(instructions);
             // NOTE: heightData offset now applied in ModelingPlanetMain prefix, not needed here
             // because heightData is already in absolute values when UpdateDirtyMesh runs
-            
+            var scalePatched = 0;
+            var modPlanePatched = 0;
+
             for (var i = 0; i < codes.Count; i++)
             {
                 if (codes[i].opcode == OpCodes.Ldarg_0 && i < codes.Count - 1)
@@ -34,6 +36,7 @@ namespace GalacticScale
                         codes[i] = new CodeInstruction(OpCodes.Nop);
                         // Instead load the fixed value 1, as a float32
                         codes[i + 1] = new CodeInstruction(OpCodes.Ldc_R4, 1f);
+                        scalePatched++;
                     }
                 }
                 else if (codes[i].Calls(typeof(PlanetRawData).GetMethod("GetModPlane")))
@@ -42,8 +45,14 @@ namespace GalacticScale
                     // We instead call PlanetRawDataExtension.GetModPlaneInt (which returns an int)
                     // All existing calls to GetModPlane cast the result to a float, anyway...
                     codes[i] = new CodeInstruction(OpCodes.Call, typeof(PlanetRawDataExtension).GetMethod("GetModPlaneInt"));
+                    modPlanePatched++;
                 }
             }
+
+            if (scalePatched == 0)
+                GS2.Error("PlanetData.UpdateDirtyMesh transpiler: this.scale loads not found (game update changed the method?). Mesh updates may double-apply planet scale.");
+            if (modPlanePatched == 0)
+                GS2.Error("PlanetData.UpdateDirtyMesh transpiler: GetModPlane calls not found (game update changed the method?). Height mods on planets larger than ~327 radius may overflow.");
 
             return codes.AsEnumerable();
         }

--- a/Scripts/Patches/PlanetModelingManager/ModelingPlanetMain.cs
+++ b/Scripts/Patches/PlanetModelingManager/ModelingPlanetMain.cs
@@ -20,6 +20,8 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> ModelingPlanetMainTranspiler(IEnumerable<CodeInstruction> instructions)
         {
             var instructionList = new List<CodeInstruction>(instructions);
+            var lodPatched = 0;
+            var modPlanePatched = 0;
 
             //Patch.Debug("ModelingPlanetMain Transpiler.", LogLevel.Debug, Patch.DebugPlanetModelingManagerDeep);
             for (var instructionCounter = 0; instructionCounter < instructionList.Count; instructionCounter++)
@@ -41,13 +43,20 @@ namespace GalacticScale
                             new(OpCodes.Div)
                         };
                         instructionList.InsertRange(instructionCounter + 3, toInsert);
+                        lodPatched++;
                     }
                 }
                 else if (instructionList[instructionCounter].Calls(typeof(PlanetRawData).GetMethod("GetModPlane")))
                 {
                     //GS2.Log("Found GetModPlane callvirt. Replacing with GetModPlaneInt call.");
                     instructionList[instructionCounter] = new CodeInstruction(OpCodes.Call, typeof(PlanetRawDataExtension).GetMethod("GetModPlaneInt"));
+                    modPlanePatched++;
                 }
+
+            if (lodPatched == 0)
+                GS2.Error("PlanetModelingManager.ModelingPlanetMain transpiler: realRadius+0.2f/0.025f LOD pattern not found (game update changed the method?). Planet mesh LOD will assume a radius-200 planet.");
+            if (modPlanePatched == 0)
+                GS2.Error("PlanetModelingManager.ModelingPlanetMain transpiler: GetModPlane call not found (game update changed the method?). Height mods on planets larger than ~327 radius may overflow.");
 
             return instructionList.AsEnumerable();
         }

--- a/Scripts/Patches/Transpilers/BuildTool_Click/CheckBuildConditions.cs
+++ b/Scripts/Patches/Transpilers/BuildTool_Click/CheckBuildConditions.cs
@@ -12,7 +12,15 @@ namespace GalacticScale
         [HarmonyTranspiler]
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            var matcher = new CodeMatcher(instructions).End().MatchBack(false, new CodeMatch(OpCodes.Ldarg_0), new CodeMatch(OpCodes.Ldflda, AccessTools.Field(typeof(BuildTool_Click), nameof(BuildTool_Click.cursorTarget)))).Advance(1);
+            var matcher = new CodeMatcher(instructions).End().MatchBack(false, new CodeMatch(OpCodes.Ldarg_0), new CodeMatch(OpCodes.Ldflda, AccessTools.Field(typeof(BuildTool_Click), nameof(BuildTool_Click.cursorTarget))));
+            if (matcher.IsInvalid)
+            {
+                // Without this guard a failed match resets the cursor and the loop below would
+                // delete instructions from the start of the method.
+                GS2.Error("BuildTool_Click.CheckBuildConditions transpiler: cursorTarget pattern not found (game update changed the method?). Returning original code - click-build reach will assume a radius-200 planet.");
+                return instructions;
+            }
+            matcher.Advance(1);
 
             while (matcher.Opcode != OpCodes.Stloc_S) matcher.RemoveInstruction();
 

--- a/Scripts/Patches/Transpilers/BuildTool_Click/DeterminePreviews.cs
+++ b/Scripts/Patches/Transpilers/BuildTool_Click/DeterminePreviews.cs
@@ -36,16 +36,22 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> BuildTool_Click_DeterminePreviews_Transpiler(
             IEnumerable<CodeInstruction> instructions)
         {
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(true,
                     new CodeMatch(i =>
                         i.opcode == OpCodes.Callvirt && ((MethodInfo)i.operand).Name == "get_realRadius"),
-                    new CodeMatch(OpCodes.Call))
+                    new CodeMatch(OpCodes.Call));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("BuildTool_Click.DeterminePreviews transpiler: realRadius pattern not found (game update changed the method?). Returning original code - preview reach will be uncapped on large planets.");
+                return instructions;
+            }
+
+            return matcher
                 .InsertAndAdvance(Transpilers.EmitDelegate<Func<float, float>>(realRadius =>
                 {
                     return Mathf.Min(realRadius * 0.025f, 20f) / 0.025f;
                 })).InstructionEnumeration();
-            return instructions;
         }
     }
 

--- a/Scripts/Patches/Transpilers/BuildTool_PathAddon/FindPotentialBelt.cs
+++ b/Scripts/Patches/Transpilers/BuildTool_PathAddon/FindPotentialBelt.cs
@@ -13,16 +13,21 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> FindPotentialBeltTranspiler(
             IEnumerable<CodeInstruction> instructions)
         {
-            instructions = new CodeMatcher(instructions).MatchForward(true,
+            var matcher = new CodeMatcher(instructions).MatchForward(true,
                     new CodeMatch(i => i.opcode == Ldloc_S),
                     new CodeMatch(i => i.opcode == Ldloc_S),
                     new CodeMatch(i => i.opcode == Ldelem && i.operand.ToString().Contains("UnityEngine.Vector3")),
-                    new CodeMatch(i => i.opcode == Ldc_R4 && (float)i.operand == 2f))
+                    new CodeMatch(i => i.opcode == Ldc_R4 && (float)i.operand == 2f));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("BuildTool_Addon.FindPotentialBelt transpiler: Vector3/2f pattern not found (game update changed the method?). Returning original code - addon belt snapping will assume a radius-200 planet.");
+                return instructions;
+            }
+
+            return matcher
                 .SetInstructionAndAdvance(new CodeInstruction(Call,
                     typeof(Utils).GetMethod(nameof(Utils.GetPlanetSizeRatio2))))
                 .InstructionEnumeration();
-
-            return instructions;
         }
     }
 }

--- a/Scripts/Patches/Transpilers/DFTinderComponent/TinderSailLogic.cs
+++ b/Scripts/Patches/Transpilers/DFTinderComponent/TinderSailLogic.cs
@@ -16,14 +16,19 @@ namespace GalacticScale
         {
             var radiusField = AccessTools.Field(typeof(AstroData), nameof(AstroData.uRadius));
             var capMethod = AccessTools.Method(typeof(DarkFogRadius), nameof(DarkFogRadius.CapStarRadiusToVanillaMax));
+            var patched = 0;
             foreach (var instruction in instructions)
             {
                 yield return instruction;
                 if (instruction.LoadsField(radiusField))
                 {
                     yield return new CodeInstruction(OpCodes.Call, capMethod);
+                    patched++;
                 }
             }
+
+            if (patched == 0)
+                GS2.Error("DFTinderComponent.TinderSailLogic transpiler: no uRadius loads found (game update changed the method?). Dark Fog tinder pathing around large stars will use unclamped radii.");
         }
     }
 }

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/CalculateGeothermalStrength.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/CalculateGeothermalStrength.cs
@@ -19,7 +19,7 @@ namespace GalacticScale
 
     public static IEnumerable<CodeInstruction> Fix201f(IEnumerable<CodeInstruction> instructions)
         {
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i =>
@@ -29,15 +29,20 @@ namespace GalacticScale
                                    Convert.ToDouble(i.operand ?? 0.0) == 201.0
                             );
                     })
-                )
-                .Repeat(matcher =>
-                {
-                    matcher.Advance(1);
-                    matcher.SetAndAdvance(Ldarg_0, null);
-                    matcher.InsertAndAdvance(new CodeInstruction(Call, AccessTools.Method(typeof(PatchOnPowerSystem), nameof(FixRadius))));
-                }).InstructionEnumeration();
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("PowerSystem.CalculateGeothermalStrength transpiler: 201f constant not found (game update changed the method?). Returning original code - geothermal strength will use vanilla radius.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    m.Advance(1);
+                    m.SetAndAdvance(Ldarg_0, null);
+                    m.InsertAndAdvance(new CodeInstruction(Call, AccessTools.Method(typeof(PatchOnPowerSystem), nameof(FixRadius))));
+                }).InstructionEnumeration();
         }
     }
 }

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/EnemyUnitComponentTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/EnemyUnitComponentTranspiler.cs
@@ -17,21 +17,25 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> Fix225(IEnumerable<CodeInstruction> instructions)
         {
             // Bootstrap.DumpInstructions(instructions, nameof(EnemyUnitComponent.RunBehavior_Defense_Ground),290, 20);
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i => (i.opcode == Ldc_R4 || i.opcode == Ldc_R8 || i.opcode == Ldc_I4) && Math.Abs(Convert.ToDouble(i.operand ?? 0.0) - 225.0) < 0.01f)
-                )
-                .Repeat(matcher =>
-                {
-                    // Bootstrap.Logger.LogInfo($"Found value {matcher.Operand} at {matcher.Pos} type {matcher.Operand?.GetType()}");
-                    var mi = matcher.GetRadiusFromAltitude();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(Utils.LoadArgument(5));
-                    matcher.Insert(new CodeInstruction(Call, mi));
-                }).InstructionEnumeration();
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("EnemyUnitComponent.RunBehavior_Defense_Ground transpiler: 225 constant not found (game update changed the method?). Returning original code - DF ground defense range will assume a radius-200 planet.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    var mi = m.GetRadiusFromAltitude();
+                    m.Advance(1);
+                    m.InsertAndAdvance(Utils.LoadArgument(5));
+                    m.Insert(new CodeInstruction(Call, mi));
+                }).InstructionEnumeration();
         }
         
         [HarmonyTranspiler]
@@ -41,7 +45,7 @@ namespace GalacticScale
         {
             // var methodInfo = AccessTools.Method(typeof(EnemyUnitComponentTranspiler), nameof(Utils.GetRadiusFromFactory));
             
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i =>
@@ -52,20 +56,25 @@ namespace GalacticScale
                                     Convert.ToDouble(i.operand ?? 0.0) == 202.0 ||
                                     Convert.ToDouble(i.operand ?? 0.0) == 206.0 ||
                                     Convert.ToDouble(i.operand ?? 0.0) == 212.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 225.0 
+                                    Convert.ToDouble(i.operand ?? 0.0) == 225.0
 
                             );
                     })
-                )
-                .Repeat(matcher =>
-                {
-                    var mi = matcher.GetRadiusFromFactory();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(new CodeInstruction(Ldarg_1));
-                    matcher.Insert(new CodeInstruction(Call, mi));
-                }).InstructionEnumeration();
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("EnemyUnitComponent GRaider/GRanger transpiler: radius constants not found (game update changed the method?). Returning original code - DF ground raider ranges will assume a radius-200 planet.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    var mi = m.GetRadiusFromFactory();
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Ldarg_1));
+                    m.Insert(new CodeInstruction(Call, mi));
+                }).InstructionEnumeration();
         }
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(EnemyUnitComponent),  nameof(EnemyUnitComponent.RunBehavior_Engage_SHumpback))] //200 but need to find the planet...
@@ -73,43 +82,50 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> Fix200(IEnumerable<CodeInstruction> instructions)
         {
             // var methodInfo = AccessTools.Method(typeof(EnemyUnitComponentTranspiler), nameof(Utils.GetRadiusFromEnemyData));
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i => i.opcode == Ldc_R8 && Convert.ToDouble(i.operand ?? 0.0) == 200.0)
-                )
-                .Repeat(matcher =>
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("EnemyUnitComponent.RunBehavior_Engage_SHumpback transpiler: 200.0 constant not found (game update changed the method?). Returning original code - Humpback engagement will assume a radius-200 planet.");
+                return instructions;
+            }
+
+            return matcher
+                .Repeat(m =>
                 {
-                    var mi = matcher.GetRadiusFromEnemyData();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(new CodeInstruction(Ldarg_S, (sbyte)3));
-                    matcher.Insert(new CodeInstruction(Call, mi));
-
-                    // Bootstrap.DumpMatcherPost(matcher, 3, 5, 5);
+                    var mi = m.GetRadiusFromEnemyData();
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Ldarg_S, (sbyte)3));
+                    m.Insert(new CodeInstruction(Call, mi));
                 }).InstructionEnumeration();
-
-            return instructions;
         }
         
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(EnemyUnitComponent),  nameof(EnemyUnitComponent.RunBehavior_OrbitTarget_SLancer))] //200 but need to find the planet...
         public static IEnumerable<CodeInstruction> Fix200Slancer(IEnumerable<CodeInstruction> instructions)
         {
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i => i.opcode == Ldc_R8 && Convert.ToDouble(i.operand ?? 0.0) == 200.0)
-                )
-                .Repeat(matcher =>
-                {
-                    // var mi = methodInfo.MakeGenericMethod(matcher.Operand?.GetType() ?? typeof(float));
-                    var mi =matcher.GetRadiusFromEnemyData();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(Utils.LoadArgument(4));
-                    matcher.Insert(new CodeInstruction(Call, mi));
-                }).InstructionEnumeration();
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("EnemyUnitComponent.RunBehavior_OrbitTarget_SLancer transpiler: 200.0 constant not found (game update changed the method?). Returning original code - Lancer orbit will assume a radius-200 planet.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    var mi = m.GetRadiusFromEnemyData();
+                    m.Advance(1);
+                    m.InsertAndAdvance(Utils.LoadArgument(4));
+                    m.Insert(new CodeInstruction(Call, mi));
+                }).InstructionEnumeration();
         }
 
         [HarmonyTranspiler]
@@ -118,18 +134,25 @@ namespace GalacticScale
         [HarmonyPatch(typeof(EnemyUnitComponent), nameof(EnemyUnitComponent.SeekToHive_Space_FollowLeader))]
         [HarmonyPatch(typeof(EnemyUnitComponent), nameof(EnemyUnitComponent.SeekToTargetPoint_Space))]
         [HarmonyPatch(typeof(EnemyUnitComponent), nameof(EnemyUnitComponent.SeekToTargetPoint_Space_FollowLeader))]
-        public static IEnumerable<CodeInstruction> CapStarRadiusToVanilla(IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> CapStarRadiusToVanilla(IEnumerable<CodeInstruction> instructions, System.Reflection.MethodBase __originalMethod)
         {
             var radiusField = AccessTools.Field(typeof(AstroData), nameof(AstroData.uRadius));
             var capMethod = AccessTools.Method(typeof(DarkFogRadius), nameof(DarkFogRadius.CapStarRadiusToVanillaMax));
+            var patched = 0;
             foreach (var instruction in instructions)
             {
                 yield return instruction;
                 if (instruction.LoadsField(radiusField))
                 {
                     yield return new CodeInstruction(Call, capMethod);
+                    patched++;
                 }
             }
+
+            // Warn, not Error: this transpiler blankets several seek methods and some
+            // (currently the FollowLeader variants) legitimately contain no uRadius reads.
+            if (patched == 0)
+                GS2.Warn($"EnemyUnitComponent space-seek transpiler: no uRadius loads in {__originalMethod?.Name} (normal for some blanket-listed targets; if this appears for a method that previously patched, a game update changed it).");
         }
     }
 }

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -35,10 +35,10 @@ namespace GalacticScale
         [HarmonyPatch(typeof(SpaceCapsule), nameof(SpaceCapsule.LateUpdate))]
         
 
-        public static IEnumerable<CodeInstruction> Fix200f(IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> Fix200f(IEnumerable<CodeInstruction> instructions, System.Reflection.MethodBase __originalMethod)
         {
             var methodInfo = AccessTools.Method(typeof(Utils), nameof(Utils.GetRadiusFromLocalPlanet));
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i =>
@@ -57,19 +57,29 @@ namespace GalacticScale
                                     Convert.ToDouble(i.operand ?? 0.0) == 212.0 ||
                                     Convert.ToDouble(i.operand ?? 0.0) == 225.0 ||
                                     Convert.ToDouble(i.operand ?? 0.0) == 228.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 255.0 
+                                    Convert.ToDouble(i.operand ?? 0.0) == 255.0
                             );
                     })
-                )
-                .Repeat(matcher =>
-                {
-                    // Bootstrap.Logger.LogInfo($"Found value {matcher.Operand} at {matcher.Pos} type {matcher.Operand?.GetType()}");
-                    var mi = methodInfo.MakeGenericMethod(matcher.Operand?.GetType() ?? typeof(float));
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(new CodeInstruction(Call, mi));
-                }).InstructionEnumeration();
+                );
+            // The transpiler runs once per target method; every target was chosen because it
+            // contains at least one of the radius constants above. Zero matches therefore means
+            // a game update removed/changed them in THIS method - report which one and leave it
+            // vanilla instead of letting Repeat() throw (which would abort the rest of
+            // Bootstrap's patch registration).
+            if (matcher.IsInvalid)
+            {
+                GS2.Error($"PlanetSizeTranspiler: no known radius constant found in {__originalMethod?.DeclaringType?.Name}.{__originalMethod?.Name} (game update changed it?). That method will use vanilla radius-200 behavior.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    // Bootstrap.Logger.LogInfo($"Found value {m.Operand} at {m.Pos} type {m.Operand?.GetType()}");
+                    var mi = methodInfo.MakeGenericMethod(m.Operand?.GetType() ?? typeof(float));
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Call, mi));
+                }).InstructionEnumeration();
         }
     }
 }

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/UnitComponentTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/UnitComponentTranspiler.cs
@@ -20,7 +20,7 @@ namespace GalacticScale
         {
             // var methodInfo = AccessTools.Method(typeof(EnemyUnitComponentTranspiler), nameof(Utils.GetRadiusFromFactory));
             
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i =>
@@ -28,22 +28,25 @@ namespace GalacticScale
                         return (i.opcode == Ldc_R4 || i.opcode == Ldc_R8 || i.opcode == Ldc_I4) &&
                                (
                                    Convert.ToDouble(i.operand ?? 0.0) == 212.0 ||
-                                   Convert.ToDouble(i.operand ?? 0.0) == 225.0 
+                                   Convert.ToDouble(i.operand ?? 0.0) == 225.0
 
                                );
                     })
-                )
-                .Repeat(matcher =>
-                {
-                    // Bootstrap.Logger.LogInfo($"Found value {matcher.Operand} at {matcher.Pos} type {matcher.Operand?.GetType()}");
-                    // var mi = methodInfo.MakeGenericMethod(matcher.Operand?.GetType() ?? typeof(float));
-                    var mi = matcher.GetRadiusFromFactory();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(new CodeInstruction(Ldarg_1));
-                    matcher.InsertAndAdvance(new CodeInstruction(Call, mi));
-                }).InstructionEnumeration();
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("UnitComponent ground-engage transpiler: 212/225 radius constants not found (game update changed the method?). Returning original code - ground unit engagement ranges will assume a radius-200 planet.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m =>
+                {
+                    var mi = m.GetRadiusFromFactory();
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Ldarg_1));
+                    m.InsertAndAdvance(new CodeInstruction(Call, mi));
+                }).InstructionEnumeration();
         }
         
         // Mecha
@@ -54,22 +57,25 @@ namespace GalacticScale
         {
             // var methodInfo = AccessTools.Method(typeof(UnitComponentTranspiler), nameof(UnitComponentTranspiler.GetRadiusFromMecha));
             
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
                     new CodeMatch(i => (i.opcode == Ldc_R4 || i.opcode == Ldc_R8 || i.opcode == Ldc_I4) && Convert.ToDouble(i.operand ?? 0.0) == 200.0)
-                )
-                .Repeat(matcher =>
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("UnitComponent mecha-engage transpiler: 200 radius constant not found (game update changed the method?). Returning original code - mecha engagement ranges will assume a radius-200 planet.");
+                return instructions;
+            }
+
+            return matcher
+                .Repeat(m =>
                 {
-                    // Bootstrap.Logger.LogInfo($"Found value {matcher.Operand} at {matcher.Pos} type {matcher.Operand?.GetType()}");
-                    // var mi = methodInfo.MakeGenericMethod(matcher.Operand?.GetType() ?? typeof(float));
-                    var mi =matcher.GetRadiusFromMecha();
-                    matcher.Advance(1);
-                    matcher.InsertAndAdvance(new CodeInstruction(Ldarg_2));
-                    matcher.InsertAndAdvance(new CodeInstruction(Call, mi));
+                    var mi = m.GetRadiusFromMecha();
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Ldarg_2));
+                    m.InsertAndAdvance(new CodeInstruction(Call, mi));
                 }).InstructionEnumeration();
-        
-            return instructions;
         }
         
         

--- a/Scripts/Patches/Transpilers/SectorModel/CreateGalaxyAstroBuffer.cs
+++ b/Scripts/Patches/Transpilers/SectorModel/CreateGalaxyAstroBuffer.cs
@@ -13,15 +13,20 @@ namespace GalacticScale
             IEnumerable<CodeInstruction> instructions)
         {
             var calcMethod = AccessTools.Method(typeof(PatchOnSectorModel), nameof(CalcAstroBufferSize));
-            instructions = new CodeMatcher(instructions)
+            var matcher = new CodeMatcher(instructions)
                 // Replace 25600 with the result of the CalcAstroBufferSize method
                 .MatchForward(
                     true,
                     new CodeMatch(i => { return i.opcode == Ldc_I4 && Convert.ToInt32(i.operand ?? 0) == 25600; }
-                    ))
-                .Repeat(matcher => { matcher.SetInstructionAndAdvance(new CodeInstruction(Call, calcMethod)); }).InstructionEnumeration();
+                    ));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("SectorModel.CreateGalaxyAstroBuffer transpiler: 25600 astro buffer constant not found (game update changed the method?). Returning original code - galaxies over 64 stars may fail to render.");
+                return instructions;
+            }
 
-            return instructions;
+            return matcher
+                .Repeat(m => { m.SetInstructionAndAdvance(new CodeInstruction(Call, calcMethod)); }).InstructionEnumeration();
         }
 
         public static int CalcAstroBufferSize()

--- a/Scripts/Patches/Transpilers/UIAchievementPanel/LoadData_Transpiler.cs
+++ b/Scripts/Patches/Transpilers/UIAchievementPanel/LoadData_Transpiler.cs
@@ -18,6 +18,11 @@ namespace GalacticScale
         public static IEnumerable<CodeInstruction> LoadData_Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             var matcher = new CodeMatcher(instructions).MatchForward(true, new CodeMatch(OpCodes.Br));
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("UIAchievementPanel.LoadData transpiler: no br instruction found (game update changed the method?). Returning original code - duplicate-key guard for achievements disabled.");
+                return instructions;
+            }
 
             var continueJmp = matcher.Operand;
 

--- a/Scripts/Patches/UIPlanetDetail/OnPlanetDataSet.cs
+++ b/Scripts/Patches/UIPlanetDetail/OnPlanetDataSet.cs
@@ -131,6 +131,7 @@ namespace GalacticScale
 		{
 			var code = new List<CodeInstruction>(instructions);
 			var safeRomanMethod = AccessTools.Method(typeof(PatchOnUIPlanetDetail), nameof(SafeOrbitRoman));
+			var patched = 0;
 
 			for (var i = 0; i < code.Count - 2; i++)
 			{
@@ -143,6 +144,7 @@ namespace GalacticScale
 					yield return code[i + 1];
 					yield return new CodeInstruction(OpCodes.Call, safeRomanMethod);
 					i += 2;
+					patched++;
 					continue;
 				}
 
@@ -153,6 +155,9 @@ namespace GalacticScale
 			{
 				yield return code[i];
 			}
+
+			if (patched == 0)
+				GS2.Error("UIPlanetDetail.OnPlanetDataSet transpiler: NameGen.roman index pattern not found (game update changed the method?). Outer-planet roman numerals may throw on high orbit counts.");
 		}
 
 		/*


### PR DESCRIPTION
## Problem

GS2 has ~51 IL transpilers that pattern-match game code, and 13 files applied their patches with **no failure handling**. When a game update changes the target IL, an unguarded transpiler fails one of three ways:

- **silently no-ops** — the feature quietly stops being scaled, nothing in the log;
- **corrupts the method** — `BuildTool_Click.CheckBuildConditions` had a `while (…) RemoveInstruction()` loop after an unchecked `MatchBack`: on a miss it would delete instructions from the start of the game's method;
- **throws from `Repeat()`** — and since `Bootstrap` wraps all ~96 `PatchAll` calls in a single try/catch, one throw aborts **every later patch registration** (cascade failure).

## Change

Failure guards on every previously-unguarded transpiler, following the two idioms already used elsewhere in the codebase: `CodeMatcher` chains check `IsInvalid` after the final match and return the **original instructions** with a `GS2.Error` naming the site and the gameplay consequence; yield-based/hand-rolled transpilers count replacements and report zero at the end. Stacked-target transpilers name the specific failing method via `__originalMethod`; the space-seek set uses `Warn` for zero-match since blanket-listed targets can legitimately contain no sites (the FollowLeader variants currently don't).

No behavior change when patterns match — verified success-path equivalence, plus a second-model code review and two in-game sessions.

## The guards immediately paid for themselves

First in-game run surfaced **four previously-invisible dead patch sites** in the current game (0.10.34.28529):
1. `PowerSystem.CalculateGeothermalStrength` — the `201f` constant no longer exists (game uses `196` now); the dedicated geothermal fix has been dead, and the generic fallback substitutes the *local* planet's radius into a possibly-remote PowerSystem (may relate to #254/#215).
2. `BuildTool_BlueprintPaste.GenerateBlueprintGratBoxes` — its only radius constant is `200.22`, and `Convert.ToDouble(200.22f) != 200.22` means that entry **never matched** (float→double precision; same for `197.6`) — may relate to #268/#168.
3. `SpaceCapsule.LateUpdate` — the game uses `201` there, which is in nobody's constant list.
4. The roman-numeral transpiler — broken by an IL shape change in .28529 (fix in a follow-up PR).

Each gets its own follow-up PR since fixing them activates code that has never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
