### PR TITLE
Pin BepInEx.Core to 5.4.17 to match the runtime pack (removes the startup version warning)

### DIFF
--- a/GalacticScale3.csproj
+++ b/GalacticScale3.csproj
@@ -23,7 +23,7 @@
     
     <ItemGroup>
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-        <PackageReference Include="BepInEx.Core" Version="5.*" />
+        <PackageReference Include="BepInEx.Core" Version="5.4.17" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.53" IncludeAssets="compile" />
 <!--       <PackageReference Include="DysonSphereProgram.GameLibs" Version="0.10.34.28347-r.0" IncludeAssets="compile" />-->


### PR DESCRIPTION
## Problem

Every GS2 user's log shows `Plugin [Galactic Scale 2 Plug-In] targets a wrong version of BepInEx (5.4.20.0) and might not work until you update` on every launch. The csproj references `BepInEx.Core 5.*`, which NuGet resolves to its newest 5.4.20+, while the BepInEx pack DSP players actually run (via r2modman/Thunderstore dependency) is **5.4.17**.

## Change

Pin the compile-time reference to `5.4.17` to match the deployed runtime. One line.

## Verification

Assembly references inspected before/after (`BepInEx 5.4.20.0` → `5.4.17.0`), and confirmed in game: GS2 no longer appears in the chainloader's version-warning list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
