### PR TITLE
Compare radius constants in the operand's own type

### DIFF
--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -10,6 +10,43 @@ namespace GalacticScale
     
     public class PlanetSizeTranspiler
     {
+        // Radius-derived constants the game hardcodes for the vanilla 200m planet.
+        private static readonly double[] RadiusConstants =
+            { 196, 197.5, 197.6, 198.5, 200, 200.22, 200.5, 202, 206, 212, 225, 228, 255 };
+
+        private static bool IsRadiusConstant(CodeInstruction i)
+        {
+            // Compare in the operand's own type, and with EXACT equality on purpose: these
+            // are compiler-emitted literal bit patterns, not measured geometry, so an
+            // epsilon would only risk matching unrelated nearby constants. Fractional
+            // constants like 200.22f widen to 200.2200012... as double, so the old
+            // Convert.ToDouble comparison against the double literal could never match an
+            // ldc.r4 operand - that silently left
+            // BuildTool_BlueprintPaste.GenerateBlueprintGratBoxes (200.22f) unpatched.
+            if (i.opcode == Ldc_R4 && i.operand is float f)
+            {
+                foreach (var c in RadiusConstants)
+                    if (f == (float)c)
+                        return true;
+                return false;
+            }
+            if (i.opcode == Ldc_R8 && i.operand is double d)
+            {
+                foreach (var c in RadiusConstants)
+                    if (d == c)
+                        return true;
+                return false;
+            }
+            if (i.opcode == Ldc_I4 && i.operand is int n)
+            {
+                foreach (var c in RadiusConstants)
+                    if (n == c)
+                        return true;
+                return false;
+            }
+            return false;
+        }
+
        [HarmonyTranspiler]
         [HarmonyPatch(typeof(BlueprintUtils), nameof(BlueprintUtils.GetNormalizedDir))]
         [HarmonyPatch(typeof(BlueprintUtils), nameof(BlueprintUtils.GetNormalizedPos))]
@@ -41,25 +78,7 @@ namespace GalacticScale
             var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
-                    new CodeMatch(i =>
-                    {
-                        return (i.opcode == Ldc_R4 || i.opcode == Ldc_R8 || i.opcode == Ldc_I4) &&
-                               (
-                                    Convert.ToDouble(i.operand ?? 0.0) == 196.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 197.5 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 197.6 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 198.5 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 200.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 200.22 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 200.5 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 202.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 206.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 212.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 225.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 228.0 ||
-                                    Convert.ToDouble(i.operand ?? 0.0) == 255.0
-                            );
-                    })
+                    new CodeMatch(IsRadiusConstant)
                 );
             // The transpiler runs once per target method; every target was chosen because it
             // contains at least one of the radius constants above. Zero matches therefore means


### PR DESCRIPTION
Related: #268, #168 (retest requested there).

The PlanetSizeTranspiler matcher compared every ldc operand via Convert.ToDouble against double literals. Fractional float constants do not round-trip through that widening — 200.22f becomes 200.2200012..., which can never equal 200.22 — so the two 200.22f sites in BuildTool_BlueprintPaste.GenerateBlueprintGratBoxes were silently never patched (the startup guard error for that method was this bug), leaving blueprint grat boxes computed with vanilla radius on resized planets.

The fix matches ldc.r4 operands against the constants converted to float, ldc.r8 against double, ldc.i4 against int — exact equality on purpose: these are compiler-emitted literal bit patterns, so an epsilon would only risk matching unrelated nearby constants. The constant list is a transcription of the old chain (same 13 values), not a new set.

Note: SpaceCapsule.LateUpdate still trips the zero-match guard after this PR (its 201f is not in the list) — that is the next, stacked PR.

Verification:
- IL census of all 19 unique target methods: the ONLY behavior change is GenerateBlueprintGratBoxes gaining its two 200.22f patches — every other site already matched exactly (integer-valued floats, doubles, and ints round-trip fine).
- Whole-surface Harmony harness against the real game dll: 19/19 methods census-exact, GenerateBlueprintGratBoxes 0 → 2, both new sites adjacent to ldc.r4 200.22 with float-typed scaling calls; full patch audit passes.
- Empirically pinned: (float)197.6 == 197.6f and (float)200.22 == 200.22f (no double-rounding hazard in the list).
- In-game on a size-520 planet: 20x40 foundation blueprint created and pasted with foundations — identical footprint, no errors. Startup guard error for GenerateBlueprintGratBoxes is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)