### PR TITLE
Derive geothermal radius from the owning PowerSystem's planet

### DIFF
--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/CalculateGeothermalStrength.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/CalculateGeothermalStrength.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HarmonyLib;
-using UnityEngine;
 using static System.Reflection.Emit.OpCodes;
 
 namespace GalacticScale
@@ -9,39 +8,48 @@ namespace GalacticScale
 {
     public partial class PatchOnPowerSystem
     {
-        public float FixRadius(PowerSystem instance)
+        public static float GetGeothermalRadiusConstant(float vanilla, PowerSystem powerSystem)
         {
-            return instance.planet.realRadius + 1;
+            var planet = powerSystem?.planet;
+            if (planet == null)
+            {
+                GS2.Warn("GetGeothermalRadiusConstant: PowerSystem has no planet - using vanilla radius-200 value.");
+                return vanilla;
+            }
+            return (float)Utils.ModifyRadius(vanilla, planet.realRadius);
         }
-        
-        [HarmonyTranspiler]
-        [HarmonyPatch(typeof(PowerSystem),  nameof(PowerSystem.CalculateGeothermalStrength))]
 
-    public static IEnumerable<CodeInstruction> Fix201f(IEnumerable<CodeInstruction> instructions)
+        // PowerSystem.CalculateGeothermalStrength compares sampled terrain height against a
+        // radius-derived constant (196f = vanilla radius 200 - 4). It is patched here instead
+        // of via PlanetSizeTranspiler because the game runs it for planets other than the
+        // local one (it has a PlanetData.GetUnloadedCopy path, and rebuilds triggered while
+        // the player is elsewhere call it too), so the radius must come from the owning
+        // PowerSystem's planet, not GameMain.localPlanet.
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(PowerSystem), nameof(PowerSystem.CalculateGeothermalStrength))]
+        public static IEnumerable<CodeInstruction> FixGeothermalRadius(IEnumerable<CodeInstruction> instructions)
         {
             var matcher = new CodeMatcher(instructions)
                 .MatchForward(
                     true,
-                    new CodeMatch(i =>
-                    {
-                        return (i.opcode == Ldc_R4) &&
-                               (
-                                   Convert.ToDouble(i.operand ?? 0.0) == 201.0
-                            );
-                    })
+                    new CodeMatch(i => i.opcode == Ldc_R4 && Convert.ToDouble(i.operand ?? 0.0) == 196.0)
                 );
             if (matcher.IsInvalid)
             {
-                GS2.Error("PowerSystem.CalculateGeothermalStrength transpiler: 201f constant not found (game update changed the method?). Returning original code - geothermal strength will use vanilla radius.");
+                GS2.Error("PowerSystem.CalculateGeothermalStrength transpiler: 196f constant not found (game update changed the method?). Returning original code - geothermal strength will use vanilla radius-200 behavior.");
                 return instructions;
             }
 
+            // Each match leaves the cursor ON the ldc.r4 196. The constant stays in place and
+            // ldarg.0 + call are appended after it, so the pair consumes (vanilla, this) and
+            // pushes the planet-scaled value - net stack effect identical to the bare constant.
+            // Nothing is removed or replaced, so branch labels on surrounding code stay valid.
             return matcher
                 .Repeat(m =>
                 {
                     m.Advance(1);
-                    m.SetAndAdvance(Ldarg_0, null);
-                    m.InsertAndAdvance(new CodeInstruction(Call, AccessTools.Method(typeof(PatchOnPowerSystem), nameof(FixRadius))));
+                    m.InsertAndAdvance(new CodeInstruction(Ldarg_0));
+                    m.InsertAndAdvance(new CodeInstruction(Call, AccessTools.Method(typeof(PatchOnPowerSystem), nameof(GetGeothermalRadiusConstant))));
                 }).InstructionEnumeration();
         }
     }

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -24,7 +24,9 @@ namespace GalacticScale
         [HarmonyPatch(typeof(PlayerAction_Combat),  nameof(PlayerAction_Combat.Shoot_Plasma))]
         [HarmonyPatch(typeof(PlayerAction_Plant),  nameof(PlayerAction_Plant.UpdateRaycast))]
         [HarmonyPatch(typeof(PlayerAction_Navigate),  nameof(PlayerAction_Navigate.GameTick))]
-        [HarmonyPatch(typeof(PowerSystem),  nameof(PowerSystem.CalculateGeothermalStrength))]
+        // PowerSystem.CalculateGeothermalStrength is deliberately NOT in this list: it runs
+        // for remote planets too, so localPlanet is the wrong radius source there. It has a
+        // dedicated transpiler in CalculateGeothermalStrength.cs.
         [HarmonyPatch(typeof(MinerComponent),  nameof(MinerComponent.IsTargetVeinInRange))]
         [HarmonyPatch(typeof(BuildTool_Reform),  nameof(BuildTool_Reform.UpdateRaycastAndReform))]
         [HarmonyPatch(typeof(BuildTool_Upgrade),  nameof(BuildTool_Upgrade.UpdateRaycast))]


### PR DESCRIPTION
Related: #254, #215 (retest requested there).

PowerSystem.CalculateGeothermalStrength runs for planets other than the local one — it has a PlanetData.GetUnloadedCopy path, and rebuilds triggered while the player is elsewhere call it too — so scaling its terrain-height constant via GameMain.localPlanet gives the wrong radius whenever the power system's planet differs from the one the player is standing on.

Two changes, one behavior:
- The method is removed from the generic PlanetSizeTranspiler target list (which substitutes localPlanet-derived values).
- The dead Fix201f transpiler (201f no longer exists in the 0.10.34 method body; the game now uses 196f — this was the startup guard error for this method) is replaced with a dedicated transpiler wrapping each 196f as ModifyRadius(196, __instance.planet.realRadius), i.e. realRadius − 4, from the owning planet.

The Dark Fog ruin path (flat 3.0 + n×0.1 bonus) is radius-independent and left untouched. On the normal build-locally path, localPlanet == owning planet, so values are identical to current behavior — only remote-call behavior changes.

Merge note: this PR, #279, and the sibling radius-source PR all touch GenericPlanetSizeTranspiler.cs on adjacent lines and will conflict trivially with each other. Mechanical resolution whichever lands last: keep `public partial class PlanetSizeTranspiler`, keep both "deliberately NOT in this list" comments, and leave neither CalculateGeothermalStrength nor IsTargetVeinInRange as Fix200f targets (keeping a generic target alongside its dedicated transpiler would double-wrap that method).

Verification:
- Harmony harness against the real game dll: all three 196f sites wrapped with ldarg.0 + call to the owning-planet helper; zero stray localPlanet calls remain in the method; full patch audit passes.
- In-game: DF core crater = 330% preview / 15.8 MW placed (ruin bonus intact); size-240 molten world = 10-110% by location, produces power. Startup guard error for this method is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)