### PR TITLE
Derive miner vein-range radius from the owning factory's planet

### DIFF
--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -8,7 +8,7 @@ namespace GalacticScale
 
 {
     
-    public class PlanetSizeTranspiler
+    public partial class PlanetSizeTranspiler
     {
        [HarmonyTranspiler]
         [HarmonyPatch(typeof(BlueprintUtils), nameof(BlueprintUtils.GetNormalizedDir))]
@@ -25,7 +25,10 @@ namespace GalacticScale
         [HarmonyPatch(typeof(PlayerAction_Plant),  nameof(PlayerAction_Plant.UpdateRaycast))]
         [HarmonyPatch(typeof(PlayerAction_Navigate),  nameof(PlayerAction_Navigate.GameTick))]
         [HarmonyPatch(typeof(PowerSystem),  nameof(PowerSystem.CalculateGeothermalStrength))]
-        [HarmonyPatch(typeof(MinerComponent),  nameof(MinerComponent.IsTargetVeinInRange))]
+        // MinerComponent.IsTargetVeinInRange is deliberately NOT in this list: it is static
+        // and also runs for remote planets (CreateEntityLogicComponents re-checks prebuild
+        // vein IDs during BAB rebuild while the player is elsewhere), so localPlanet is the
+        // wrong radius source there. It has a dedicated transpiler in IsTargetVeinInRange.cs.
         [HarmonyPatch(typeof(BuildTool_Reform),  nameof(BuildTool_Reform.UpdateRaycastAndReform))]
         [HarmonyPatch(typeof(BuildTool_Upgrade),  nameof(BuildTool_Upgrade.UpdateRaycast))]
         [HarmonyPatch(typeof(BuildTool_Path),  nameof(BuildTool_Path.UpdateRaycast))]

--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/IsTargetVeinInRange.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/IsTargetVeinInRange.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using static System.Reflection.Emit.OpCodes;
+
+namespace GalacticScale
+{
+    public partial class PlanetSizeTranspiler
+    {
+        // Owning planet for IsTargetVeinInRange. The method is static (Vector3, Pose, PrefabDesc)
+        // so there is no factory/planet argument; CreateEntityLogicComponents is the only 0.10.34
+        // caller that is not local-planet-scoped (BAB rebuild via BuildFinally on a remote factory).
+        // HarmonyX 2.5.5 (BepInEx 5.4.17) delivers Prefix `out T __state` into a void
+        // Finalizer(T __state) on both normal return and thrown exception, including nested
+        // same-thread pushes.
+        [ThreadStatic] static PlanetData veinRangePlanet;
+
+        public static float GetVeinRangeRadiusConstant(float vanilla)
+        {
+            var planet = veinRangePlanet ?? GameMain.localPlanet;
+            if (planet == null)
+                return vanilla;
+            return (float)Utils.ModifyRadius(vanilla, planet.realRadius);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(PlanetFactory), nameof(PlanetFactory.CreateEntityLogicComponents))]
+        public static void CreateEntityLogicComponents_PushPlanet(PlanetFactory __instance, out PlanetData __state)
+        {
+            __state = veinRangePlanet;
+            veinRangePlanet = __instance.planet;
+        }
+
+        [HarmonyFinalizer]
+        [HarmonyPatch(typeof(PlanetFactory), nameof(PlanetFactory.CreateEntityLogicComponents))]
+        public static void CreateEntityLogicComponents_PopPlanet(PlanetData __state)
+        {
+            veinRangePlanet = __state;
+        }
+
+        // MinerComponent.IsTargetVeinInRange projects target and pose.position onto a radius-200
+        // sphere, then applies fixed meter-space thresholds. It is patched here instead of via
+        // PlanetSizeTranspiler.Fix200f because the game runs it for planets other than the local
+        // one (CreateEntityLogicComponents re-validates prebuild vein IDs and drops any that fail,
+        // including during off-world BAB rebuild), so the radius must come from the owning
+        // factory's planet when that context has been pushed, not GameMain.localPlanet.
+        [HarmonyTranspiler]
+        [HarmonyPatch(typeof(MinerComponent), nameof(MinerComponent.IsTargetVeinInRange))]
+        public static IEnumerable<CodeInstruction> FixVeinRangeRadius(IEnumerable<CodeInstruction> instructions)
+        {
+            var matcher = new CodeMatcher(instructions)
+                .MatchForward(
+                    true,
+                    new CodeMatch(i => i.opcode == Ldc_R4 && i.operand is float f && f == 200f)
+                );
+            if (matcher.IsInvalid)
+            {
+                GS2.Error("MinerComponent.IsTargetVeinInRange transpiler: 200f constant not found (game update changed the method?). Returning original code - vein range will use vanilla radius-200 behavior.");
+                return instructions;
+            }
+
+            // Each match leaves the cursor ON the ldc.r4 200. The constant stays in place and
+            // the helper call is appended after it, so the pair consumes (vanilla) and pushes
+            // the context-or-localPlanet scaled value - net stack effect identical to the bare
+            // constant. The method's other floats (7.75 / 6.25 / 100 / 60.0625 / 0.73 / 2.0 /
+            // -10 / -1.2) are meter-space thresholds and must not be wrapped. Nothing is
+            // removed or replaced, so branch labels on surrounding code stay valid.
+            return matcher
+                .Repeat(m =>
+                {
+                    m.Advance(1);
+                    m.InsertAndAdvance(new CodeInstruction(Call, AccessTools.Method(typeof(PlanetSizeTranspiler), nameof(GetVeinRangeRadiusConstant))));
+                }).InstructionEnumeration();
+        }
+    }
+}


### PR DESCRIPTION
Related: #234, #254 (retest requested there).

MinerComponent.IsTargetVeinInRange is static and projects target and pose.position onto a hardcoded radius-200 sphere before applying meter-space reach thresholds. The generic PlanetSizeTranspiler wraps those 200f sites with GameMain.localPlanet, which is correct for the two local callers (BuildTool_Click.CheckBuildConditions, PlayerControlGizmo.OnOutlineDraw) but wrong for PlanetFactory.CreateEntityLogicComponents: that path also runs for remote factories (automated rebuilding while the player is on another planet or in space). Because vein binding is create-time and destructive — failing veins are removed from the prebuild and copied into miner.veins, and InternalUpdate never re-checks range — a wrong projection radius permanently strips veins from a rebuilt miner.

- The method is removed from the generic PlanetSizeTranspiler target list.
- A dedicated transpiler wraps each 200f as ModifyRadius(200, owning planet), leaving the meter-space thresholds untouched.
- The owning planet is delivered via ThreadStatic, pushed by a Prefix and restored by a Finalizer on CreateEntityLogicComponents (HarmonyX 2.5.5 delivers out __state into the finalizer on both return and throw — verified by a dedicated harness against the shipped 0Harmony.dll, including nested same-thread push/pop). Local callers leave the override unset, so they keep today's localPlanet scaling exactly.

Merge note: this PR, #279, and the sibling radius-source PR all touch GenericPlanetSizeTranspiler.cs on adjacent lines and will conflict trivially with each other. Mechanical resolution whichever lands last: keep `public partial class PlanetSizeTranspiler`, keep both "deliberately NOT in this list" comments, and leave neither CalculateGeothermalStrength nor IsTargetVeinInRange as Fix200f targets (keeping a generic target alongside its dedicated transpiler would double-wrap that method).

Verification:
- Harmony harness against the real game dll: both 200f sites wrapped; the __state/finalizer contract proven on the shipped HarmonyX build; full patch audit passes.
- In-game: an evening of mining-machine placements on a size-520 world — all vein bindings correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)