### PR TITLE
Add 201 to the radius-constant list for SpaceCapsule.LateUpdate

### DIFF
--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -12,7 +12,7 @@ namespace GalacticScale
     {
         // Radius-derived constants the game hardcodes for the vanilla 200m planet.
         private static readonly double[] RadiusConstants =
-            { 196, 197.5, 197.6, 198.5, 200, 200.22, 200.5, 202, 206, 212, 225, 228, 255 };
+            { 196, 197.5, 197.6, 198.5, 200, 200.22, 200.5, 201, 202, 206, 212, 225, 228, 255 };
 
         private static bool IsRadiusConstant(CodeInstruction i)
         {


### PR DESCRIPTION
Stacked follow-up to #279 (now merged); one commit.

SpaceCapsule.LateUpdate computes position.magnitude − 201f (altitude above the vanilla surface radius + 1) to fade the capsule renderers. 201 was not in any transpiler's constant list, so the method ran with vanilla-radius behavior on resized planets and PlanetSizeTranspiler's zero-match guard logged an error for it at every launch — the last of the three startup guard errors.

An IL census of all PlanetSizeTranspiler targets shows exactly one 201 site set-wide (this one), so adding 201 to RadiusConstants is surgical: ModifyRadius(201, r) = r + 1 preserves the vanilla offset, and the method is local-planet visual work, so localPlanet scaling is the correct source.

Verification: whole-surface harness — SpaceCapsule.LateUpdate gains exactly its one injection, every other method census-identical; patch audit passes; multi-day in-game soak with zero guard errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)