### PR TITLE
Fix duplicate HarmonyPatch targets for IsTargetVeinInRange and CalculateGeothermalStrength

### DIFF
--- a/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
+++ b/Scripts/Patches/Transpilers/PlanetSizeTranspiler/GenericPlanetSizeTranspiler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
@@ -61,7 +61,6 @@ namespace GalacticScale
         [HarmonyPatch(typeof(PlayerAction_Combat),  nameof(PlayerAction_Combat.Shoot_Plasma))]
         [HarmonyPatch(typeof(PlayerAction_Plant),  nameof(PlayerAction_Plant.UpdateRaycast))]
         [HarmonyPatch(typeof(PlayerAction_Navigate),  nameof(PlayerAction_Navigate.GameTick))]
-        [HarmonyPatch(typeof(PowerSystem),  nameof(PowerSystem.CalculateGeothermalStrength))]
         // MinerComponent.IsTargetVeinInRange is deliberately NOT in this list: it is static
         // and also runs for remote planets (CreateEntityLogicComponents re-checks prebuild
         // vein IDs during BAB rebuild while the player is elsewhere), so localPlanet is the
@@ -69,7 +68,6 @@ namespace GalacticScale
         // PowerSystem.CalculateGeothermalStrength is deliberately NOT in this list: it runs
         // for remote planets too, so localPlanet is the wrong radius source there. It has a
         // dedicated transpiler in CalculateGeothermalStrength.cs.
-        [HarmonyPatch(typeof(MinerComponent),  nameof(MinerComponent.IsTargetVeinInRange))]
         [HarmonyPatch(typeof(BuildTool_Reform),  nameof(BuildTool_Reform.UpdateRaycastAndReform))]
         [HarmonyPatch(typeof(BuildTool_Upgrade),  nameof(BuildTool_Upgrade.UpdateRaycast))]
         [HarmonyPatch(typeof(BuildTool_Path),  nameof(BuildTool_Path.UpdateRaycast))]


### PR DESCRIPTION
### Summary

In PR #280 and PR #281, dedicated transpilers were introduced in \CalculateGeothermalStrength.cs\ and \IsTargetVeinInRange.cs\ to properly handle off-world / remote planet radius contexts. However, when resolving merge conflicts during the merge of these PRs into \main\ (e.g. merge commit 96726a2), the \[HarmonyPatch]\ attributes for \PowerSystem.CalculateGeothermalStrength\ and \MinerComponent.IsTargetVeinInRange\ were accidentally left in \GenericPlanetSizeTranspiler.cs\ despite the accompanying comments stating they should not be there.

### Issue & Root Cause
Because \MinerComponent.IsTargetVeinInRange\ was targeted by two transpilers simultaneously:
1. \GenericPlanetSizeTranspiler.Fix200f\ scaled the literal 200f constant via \GetRadiusFromLocalPlanet(200f)\ -> \ealRadius\ ($).
2. The dedicated transpiler \FixVeinRangeRadius\ then consumed that result as \anilla\ in \ModifyRadius(vanilla, realRadius)\, calculating  + (R - 200) = 2R - 200$.

For non-200m planets, this deformed the spherical projection radius (e.g. radius 80m becomes -40m, radius 400m becomes 600m), leading to geometry distortion where veins in range fail the distance check in \IsTargetVeinInRange\ and get removed from \miner.veins\ at build time.

### Solution
Remove the two redundant \[HarmonyPatch]\ attributes from \GenericPlanetSizeTranspiler.cs\ so each method is only transpiled once by its dedicated transpiler.