### PR TITLE
2.78.3

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -15,7 +15,7 @@ namespace GalacticScale
     }
 
  
-    [BepInPlugin("dsp.galactic-scale.2", "Galactic Scale 2 Plug-In", "2.78.2")]
+    [BepInPlugin("dsp.galactic-scale.2", "Galactic Scale 2 Plug-In", "2.78.3")]
     [BepInDependency("space.customizing.console", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("dsp.nebula-multiplayer-api", BepInDependency.DependencyFlags.SoftDependency)]
     public class Bootstrap : BaseUnityPlugin

--- a/Bootstrap.cs.bak
+++ b/Bootstrap.cs.bak
@@ -15,7 +15,7 @@ namespace GalacticScale
     }
 
  
-    [BepInPlugin("dsp.galactic-scale.2", "Galactic Scale 2 Plug-In", "2.78.1")]
+    [BepInPlugin("dsp.galactic-scale.2", "Galactic Scale 2 Plug-In", "2.78.2")]
     [BepInDependency("space.customizing.console", BepInDependency.DependencyFlags.SoftDependency)]
     [BepInDependency("dsp.nebula-multiplayer-api", BepInDependency.DependencyFlags.SoftDependency)]
     public class Bootstrap : BaseUnityPlugin

--- a/GalacticScale3.csproj
+++ b/GalacticScale3.csproj
@@ -13,7 +13,7 @@
     <PropertyGroup>
         <AssemblyName>GalacticScale</AssemblyName>
         <Description>Galaxy Customization for Dyson Sphere Program</Description>
-        <Version>2.78.2</Version>
+        <Version>2.78.3</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>9.0</LangVersion>
         <OutDir>bin/$(Configuration)</OutDir>

--- a/GalacticScale3.csproj.bak
+++ b/GalacticScale3.csproj.bak
@@ -13,7 +13,7 @@
     <PropertyGroup>
         <AssemblyName>GalacticScale</AssemblyName>
         <Description>Galaxy Customization for Dyson Sphere Program</Description>
-        <Version>2.78.1</Version>
+        <Version>2.78.2</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>9.0</LangVersion>
         <OutDir>bin/$(Configuration)</OutDir>

--- a/Package/README.md
+++ b/Package/README.md
@@ -1,6 +1,7 @@
 # DSP Galactic Scale 2.0 Mod
 
 # BACKUP YOUR SAVES. SERIOUSLY.
+- Version 2.78.3 - ZordDevzz fixed the 2.78.1 vein/geothermal radius patches being applied twice (miners not accepting veins in range, #283).
 - Version 2.78.2 - AndrewLuebke fixed another bug with the planet radius.
 - Version 2.78.1 - AndrewLuebke fixed 4 bugs with planet radius causing errors in: Beacon hover altitude, Geothermal, Blueprints and Veins.
 - Version 2.78.0 - AndrewLuebke fixed three other issues.

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -4,8 +4,8 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "Galactic_Scale"
 name = "GalacticScale"
-versionNumber = "2.78.2"
-description = "v2.78.2 Galaxy Customization. New Planets. Different Sized Planets. Up to 100 Planets/star and 1024 Stars. DF is more or less balanced. See GS Discord Server"
+versionNumber = "2.78.3"
+description = "v2.78.3 Galaxy Customization. New Planets. Different Sized Planets. Up to 100 Planets/star and 1024 Stars. DF is more or less balanced. See GS Discord Server"
 websiteUrl = "https://github.com/Touhma/DSP_Plugins"
 containsNsfwContent = false
 

--- a/thunderstore.toml.bak
+++ b/thunderstore.toml.bak
@@ -4,8 +4,8 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "Galactic_Scale"
 name = "GalacticScale"
-versionNumber = "2.78.1"
-description = "v2.78.1 Galaxy Customization. New Planets. Different Sized Planets. Up to 100 Planets/star and 1024 Stars. DF is more or less balanced. See GS Discord Server"
+versionNumber = "2.78.2"
+description = "v2.78.2 Galaxy Customization. New Planets. Different Sized Planets. Up to 100 Planets/star and 1024 Stars. DF is more or less balanced. See GS Discord Server"
 websiteUrl = "https://github.com/Touhma/DSP_Plugins"
 containsNsfwContent = false
 


### PR DESCRIPTION
Version bump so the fix from #284 can ship.

The vein-range/geothermal double-apply (a conflict-resolution artifact from the #280/#281 merges) is present in both published Thunderstore builds, 2.78.1 and 2.78.2 — it is what #283 is reporting. Current main is correct since #284, so this is a bump-only PR, mirroring the 2.78.2 bump commit exactly (including the .bak version trail).

Once the 2.78.3 package is up, #283 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)