### PR TITLE
Show landing ETA when hovering an inbound DF relay

### DIFF
--- a/Bootstrap.cs
+++ b/Bootstrap.cs
@@ -138,6 +138,7 @@ namespace GalacticScale
                 harmony.PatchAll(typeof(PatchOnUIAdvisorTip));
                 harmony.PatchAll(typeof(PatchOnUIBuildingGrid));
                 harmony.PatchAll(typeof(PatchOnUICommunicatorIndicator));
+                harmony.PatchAll(typeof(PatchOnUIEnemyBriefInfo));
                 harmony.PatchAll(typeof(PatchOnUIEscMenu));
                 harmony.PatchAll(typeof(PatchOnUIGalaxySelect));
                 harmony.PatchAll(typeof(PatchOnUIGame));

--- a/Scripts/Patches/UIEnemyBriefInfo/_OnUpdateLandingEta.cs
+++ b/Scripts/Patches/UIEnemyBriefInfo/_OnUpdateLandingEta.cs
@@ -1,0 +1,40 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace GalacticScale
+{
+    public class PatchOnUIEnemyBriefInfo
+    {
+        // Extend the inbound-relay destination value ("Going to planet: <name>")
+        // with landing ETA. relayState == 1 is the inbound flag SetBriefInfo sets.
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIEnemyBriefInfo), "_OnUpdate")]
+        public static void _OnUpdate_LandingEta(UIEnemyBriefInfo __instance)
+        {
+            try
+            {
+                if (__instance?.enemyInfo == null || __instance.stateValueText == null)
+                    return;
+                if (__instance.enemyInfo.relayState != 1)
+                    return;
+
+                var sector = GameMain.data?.spaceSector ?? __instance.sector;
+                if (!RelayLandingEta.TryFormat(sector, __instance.enemyInfo.enemyId, out var label))
+                    return;
+
+                __instance.stateValueText.text = RelayLandingEta.ApplySuffix(
+                    __instance.stateValueText.text, "  ·  ", label);
+
+                var size = __instance.contentSize;
+                var need = __instance.stateValueText.preferredWidth + 16f;
+                if (need > size.x)
+                    __instance.contentSize = new Vector2(need, size.y);
+            }
+            catch (Exception e)
+            {
+                GS2.Warn("UIEnemyBriefInfo landing-ETA postfix failed: " + e.Message);
+            }
+        }
+    }
+}

--- a/Scripts/Patches/UIStarmap/UpdateCursorViewLandingEta.cs
+++ b/Scripts/Patches/UIStarmap/UpdateCursorViewLandingEta.cs
@@ -1,0 +1,47 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace GalacticScale
+{
+    public partial class PatchOnUIStarmap
+    {
+        // Append a landing-ETA line after vanilla UpdateCursorView. The existing
+        // 最快秒 player-intercept seconds are left untouched.
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(UIStarmap), nameof(UIStarmap.UpdateCursorView))]
+        public static void UpdateCursorView_LandingEta(UIStarmap __instance)
+        {
+            try
+            {
+                if (__instance?.cursorViewText == null)
+                    return;
+
+                var enemyId = __instance.focusEnemyId != 0
+                    ? __instance.focusEnemyId
+                    : __instance.mouseHoverEnemyId;
+                if (!RelayLandingEta.TryFormat(__instance.spaceSector, enemyId, out var label))
+                    return;
+
+                __instance.cursorViewText.text = RelayLandingEta.ApplySuffix(
+                    __instance.cursorViewText.text, "\r\n", label);
+
+                if (__instance.cursorViewTrans != null)
+                {
+                    __instance.cursorViewTrans.sizeDelta = new Vector2(
+                        __instance.cursorViewText.preferredWidth * 0.5f + 44f,
+                        __instance.cursorViewText.preferredHeight * 0.5f + 14f);
+                    if (__instance.cursorRightDeco != null)
+                    {
+                        __instance.cursorRightDeco.sizeDelta = new Vector2(
+                            __instance.cursorViewTrans.sizeDelta.y - 12f, 5f);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                GS2.Warn("UpdateCursorView landing-ETA postfix failed: " + e.Message);
+            }
+        }
+    }
+}

--- a/Scripts/Utils/RelayLandingEta.cs
+++ b/Scripts/Utils/RelayLandingEta.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace GalacticScale
+{
+    // Landing-ETA helper for inbound DF relays. Display-only; does not touch sail logic.
+    public static class RelayLandingEta
+    {
+        // RelaySailLogic inbound cruise clamps target uSpeed with ldc.r4 1000
+        // (IL_0724 / IL_072B). IL_0E1C divides uSpeed by the same 1000 for
+        // turn-rate once remaining distance >= 500. There is no named field
+        // for this cap: DFRelayComponent.kCarrier_Sail_Speed is 1800 and is
+        // the carrier, not the relay.
+        public const float CruiseSpeedCap = 1000f;
+
+        // Invisible marker so a postfix can replace its own suffix if the
+        // host method skipped a full text rebuild this frame.
+        const string SuffixToken = "\u2060";
+
+        public static bool TryFormat(SpaceSector sector, int enemyId, out string label)
+        {
+            label = null;
+            if (sector?.enemyPool == null || enemyId <= 0 || enemyId >= sector.enemyPool.Length)
+                return false;
+
+            var enemy = sector.enemyPool[enemyId];
+            if (enemy.id != enemyId || enemy.dfRelayId <= 0)
+                return false;
+
+            var hiveIndex = enemy.originAstroId - 1000000;
+            if (sector.dfHivesByAstro == null || hiveIndex < 0 || hiveIndex >= sector.dfHivesByAstro.Length)
+                return false;
+
+            var hive = sector.dfHivesByAstro[hiveIndex];
+            if (hive?.relays?.buffer == null)
+                return false;
+
+            var relayId = enemy.dfRelayId;
+            if (relayId < 0 || relayId >= hive.relays.buffer.Length)
+                return false;
+
+            var relay = hive.relays.buffer[relayId];
+            if (relay == null || relay.id != relayId)
+                return false;
+            if (relay.direction <= 0 || relay.targetAstroId <= 0)
+                return false;
+
+            var galaxy = GameMain.data?.galaxy ?? GameMain.galaxy;
+            var planet = galaxy?.PlanetById(relay.targetAstroId);
+            if (planet == null)
+                return false;
+
+            var lpos = enemy.pos;
+            sector.TransformFromAstro_ref(enemy.astroId, out var relayUPos, ref lpos);
+            var remain = (relayUPos - planet.uPosition).magnitude;
+            if (double.IsNaN(remain) || double.IsInfinity(remain) || remain < 0)
+                return false;
+
+            label = FormatLabel(remain / CruiseSpeedCap);
+            return !string.IsNullOrEmpty(label);
+        }
+
+        public static string ApplySuffix(string existing, string separator, string label)
+        {
+            if (string.IsNullOrEmpty(label))
+                return existing ?? "";
+            if (existing == null)
+                existing = "";
+            var cut = existing.IndexOf(SuffixToken, StringComparison.Ordinal);
+            if (cut >= 0)
+                existing = existing.Substring(0, cut).TrimEnd();
+            return existing + separator + SuffixToken + label;
+        }
+
+        static string FormatLabel(double seconds)
+        {
+            return string.Format("Lands in {0}".Translate(), FormatDuration(seconds));
+        }
+
+        static string FormatDuration(double seconds)
+        {
+            if (seconds < 1.0)
+                return "<1s";
+            var total = (int)Math.Round(seconds);
+            if (total < 60)
+                return total + "s";
+            var hours = total / 3600;
+            var minutes = total / 60 % 60;
+            var secs = total % 60;
+            if (hours > 0)
+                return hours + ":" + minutes.ToString("D2") + ":" + secs.ToString("D2");
+            return minutes + ":" + secs.ToString("D2");
+        }
+    }
+}


### PR DESCRIPTION
Feature: hovering an inbound Dark Fog relay (starmap cursor or the enemy brief-info panel) now appends a landing ETA to the tooltip. Vanilla's "arrives in Xs" on hover is the player-intercept time, not the relay's arrival — players watching a relay descend toward a beacon had no way to know when it would actually land (this confused us during the #270 verification, which is where the feature idea came from).

Implementation: `RelayLandingEta` computes remaining travel from the relay's current position, target, and the cruise-speed cap (1000 m/s, matching DFRelayComponent sail logic), with the hive looked up via `originAstroId − 1000000`. UI patches are additive postfixes on `UIStarmap.UpdateCursorView` and `UIEnemyBriefInfo._OnUpdate` that append an ETA line; an invisible token suffix keeps the append idempotent across UI refreshes. No vanilla strings are replaced; the feature is display-only.

Verified: build clean on current main; in-game confirmed (countdown appears on hover and reaches zero at touchdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)